### PR TITLE
feat(docker): write Compose files atomically

### DIFF
--- a/.changeset/atomic-compose-document-writes.md
+++ b/.changeset/atomic-compose-document-writes.md
@@ -1,0 +1,5 @@
+---
+"ayanokoji": minor
+---
+
+Write Docker Compose updates atomically while preserving permissions and rejecting symlinked, stale, or concurrently created files. Closes #20

--- a/apps/docs/src/content/docs/commands/docker.mdx
+++ b/apps/docs/src/content/docs/commands/docker.mdx
@@ -65,6 +65,14 @@ npx ayanokoji docker remove
 - **Recognized files** - Prompts when multiple supported Compose files exist and reports an error when none exists
 - **No-services result** - Treats an omitted or empty `services` collection as no removable services and leaves the document unchanged
 
+### Compose file safety
+
+Both Docker commands apply successful service transformations through the Compose file adapter:
+
+- Existing regular Compose files are replaced atomically, preserving permission mode bits.
+- Symlinked or changed Compose paths are rejected without overwriting the file; rerun the command after a stale-document conflict.
+- When initialization starts without an existing Compose file, the selected path is created exclusively so a concurrent creation is reported instead of overwritten.
+
 ## Supported Services
 
 ### Databases

--- a/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
@@ -1,12 +1,27 @@
 import { expect, test } from "bun:test";
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  link,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  symlink,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   COMPOSE_FILE_NAMES,
   type ComposeFileFailure,
+  type ComposeFileSystem,
   discoverComposeFiles,
   readComposeDocument,
+  writeComposeDocument,
 } from "./compose-file-adapter";
 
 test("discovers every supported Compose candidate without selecting one", async () => {
@@ -91,6 +106,29 @@ test("does not treat a directory with a supported name as a Compose candidate", 
   }
 });
 
+test("reports a recognized symlink during Compose discovery", async () => {
+  const cwd = await createTempDirectory();
+
+  try {
+    await writeFile(join(cwd, "user-compose.yaml"), "services: {}\n");
+    await symlink(join(cwd, "user-compose.yaml"), join(cwd, "compose.yaml"));
+
+    const result = await discoverComposeFiles(cwd);
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+
+    expect(result.error).toEqual({
+      kind: "symlinked-document",
+      fileName: "compose.yaml",
+    });
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
 test("reports an inspection failure instead of treating an inaccessible candidate as absent", async () => {
   const inaccessible = Object.assign(new Error("permission denied"), {
     code: "EACCES",
@@ -138,7 +176,7 @@ volumes:
       return;
     }
 
-    expect(result.value).toEqual({
+    expect(result.value.document).toEqual({
       name: "example",
       "x-user-extension": { enabled: true },
       services: {
@@ -174,7 +212,7 @@ test("allows a Compose document to omit services for initialization", async () =
       return;
     }
 
-    expect(result.value).toEqual({
+    expect(result.value.document).toEqual({
       name: "example",
       networks: { internal: { driver: "bridge" } },
     });
@@ -313,6 +351,301 @@ test("reports a non-missing read failure as structured data", async () => {
   });
 });
 
+test("replaces an existing Compose document through the write seam", async () => {
+  const cwd = await createTempDirectory();
+  const composePath = join(cwd, "compose.yaml");
+
+  try {
+    await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
+
+    const readResult = await readComposeDocument(cwd, "compose.yaml");
+    expect(readResult.isOk()).toBe(true);
+    if (readResult.isErr()) {
+      return;
+    }
+
+    const writeResult = await writeComposeDocument(
+      cwd,
+      "compose.yaml",
+      { services: { app: { image: "new/app" } } },
+      readResult.value.revision
+    );
+
+    expect(writeResult.isOk()).toBe(true);
+    expect((await readFile(composePath, "utf8")).toString()).toContain(
+      "image: new/app"
+    );
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
+test("preserves an existing Compose file's permission mode bits", async () => {
+  const cwd = await createTempDirectory();
+  const composePath = join(cwd, "compose.yaml");
+
+  try {
+    await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
+    await chmod(composePath, 0o640);
+
+    const readResult = await readComposeDocument(cwd, "compose.yaml");
+    expect(readResult.isOk()).toBe(true);
+    if (readResult.isErr()) {
+      return;
+    }
+
+    const writeResult = await writeComposeDocument(
+      cwd,
+      "compose.yaml",
+      { services: { app: { image: "new/app" } } },
+      readResult.value.revision
+    );
+
+    expect(writeResult.isOk()).toBe(true);
+    expect((await lstat(composePath)).mode % 0o1_0000).toBe(0o640);
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
+test("uses normal filesystem defaults when creating a new Compose file", async () => {
+  const cwd = await createTempDirectory();
+  const composePath = join(cwd, "compose.yaml");
+  const expectedPath = join(cwd, "expected-mode.txt");
+
+  try {
+    await writeFile(expectedPath, "");
+    const expectedMode = (await lstat(expectedPath)).mode % 0o1000;
+
+    const result = await writeComposeDocument(cwd, "compose.yaml", {
+      services: {},
+    });
+
+    expect(result.isOk()).toBe(true);
+    expect((await lstat(composePath)).mode % 0o1000).toBe(expectedMode);
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
+test("rejects a symlinked Compose path without replacing the link", async () => {
+  const cwd = await createTempDirectory();
+  const targetPath = join(cwd, "user-compose.yaml");
+  const composePath = join(cwd, "compose.yaml");
+  const source = "services:\n  app:\n    image: user/app\n";
+
+  try {
+    await writeFile(targetPath, source);
+    await symlink(targetPath, composePath);
+
+    const result = await writeComposeDocument(cwd, "compose.yaml", {
+      services: { app: { image: "new/app" } },
+    });
+
+    expect(result.isErr()).toBe(true);
+    if (result.isOk()) {
+      return;
+    }
+
+    expect(result.error).toEqual({
+      kind: "symlinked-document",
+      fileName: "compose.yaml",
+    });
+    expect((await lstat(composePath)).isSymbolicLink()).toBe(true);
+    expect((await readFile(targetPath, "utf8")).toString()).toBe(source);
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
+test("rejects a stale revision without overwriting newer Compose content", async () => {
+  const cwd = await createTempDirectory();
+  const composePath = join(cwd, "compose.yaml");
+  const newerSource = "services:\n  app:\n    image: newer/app\n";
+
+  try {
+    await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
+
+    const readResult = await readComposeDocument(cwd, "compose.yaml");
+    expect(readResult.isOk()).toBe(true);
+    if (readResult.isErr()) {
+      return;
+    }
+
+    await writeFile(composePath, newerSource);
+
+    const writeResult = await writeComposeDocument(
+      cwd,
+      "compose.yaml",
+      { services: { app: { image: "generated/app" } } },
+      readResult.value.revision
+    );
+
+    expect(writeResult.isErr()).toBe(true);
+    if (writeResult.isOk()) {
+      return;
+    }
+
+    expect(writeResult.error).toEqual({
+      kind: "stale-document",
+      fileName: "compose.yaml",
+    });
+    expect((await readFile(composePath, "utf8")).toString()).toBe(newerSource);
+    expect(
+      (await readdir(cwd)).filter((name) => name.startsWith(".compose.yaml."))
+    ).toEqual([]);
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
+test("reports serialization failures without touching an existing file", async () => {
+  const cwd = await createTempDirectory();
+  const composePath = join(cwd, "compose.yaml");
+  const source = "services:\n  app:\n    image: old/app\n";
+
+  try {
+    await writeFile(composePath, source);
+    const readResult = await readComposeDocument(cwd, "compose.yaml");
+    expect(readResult.isOk()).toBe(true);
+    if (readResult.isErr()) {
+      return;
+    }
+
+    const unserializableDocument = {
+      services: {},
+      value: Symbol("unsupported"),
+    };
+
+    const writeResult = await writeComposeDocument(
+      cwd,
+      "compose.yaml",
+      unserializableDocument,
+      readResult.value.revision
+    );
+
+    expect(writeResult.isErr()).toBe(true);
+    if (writeResult.isOk()) {
+      return;
+    }
+
+    expect(writeResult.error).toEqual({
+      kind: "serialization-failure",
+      fileName: "compose.yaml",
+    });
+    expect((await readFile(composePath, "utf8")).toString()).toBe(source);
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
+test("reports deterministic write failures without replacing the original", async () => {
+  const cwd = await createTempDirectory();
+  const composePath = join(cwd, "compose.yaml");
+  const source = "services:\n  app:\n    image: old/app\n";
+
+  try {
+    await writeFile(composePath, source);
+    const readResult = await readComposeDocument(cwd, "compose.yaml");
+    expect(readResult.isOk()).toBe(true);
+    if (readResult.isErr()) {
+      return;
+    }
+
+    const writeResult = await writeComposeDocument(
+      cwd,
+      "compose.yaml",
+      { services: { app: { image: "new/app" } } },
+      readResult.value.revision,
+      createFileSystem({
+        writeFile: () => Promise.reject(new Error("disk full")),
+      })
+    );
+
+    expect(writeResult.isErr()).toBe(true);
+    if (writeResult.isOk()) {
+      return;
+    }
+
+    expect(writeResult.error).toEqual({
+      kind: "write-failure",
+      fileName: "compose.yaml",
+    });
+    expect((await readFile(composePath, "utf8")).toString()).toBe(source);
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
+test("creates a new Compose file exclusively when another process wins the race", async () => {
+  const cwd = await createTempDirectory();
+  const composePath = join(cwd, "compose.yaml");
+  const competitorSource = "services:\n  competitor:\n    image: other/app\n";
+
+  try {
+    const writeResult = await writeComposeDocument(
+      cwd,
+      "compose.yaml",
+      { services: { app: { image: "new/app" } } },
+      undefined,
+      createFileSystem({
+        link: async (_temporaryPath, newPath) => {
+          await writeFile(newPath, competitorSource);
+          throw Object.assign(new Error("already exists"), { code: "EEXIST" });
+        },
+      })
+    );
+
+    expect(writeResult.isErr()).toBe(true);
+    if (writeResult.isOk()) {
+      return;
+    }
+
+    expect(writeResult.error).toEqual({
+      kind: "creation-conflict",
+      fileName: "compose.yaml",
+    });
+    expect((await readFile(composePath, "utf8")).toString()).toBe(
+      competitorSource
+    );
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
+test("reports replacement failures without leaving a temporary file", async () => {
+  const cwd = await createTempDirectory();
+  const composePath = join(cwd, "compose.yaml");
+  const source = "services:\n  app:\n    image: old/app\n";
+
+  try {
+    await writeFile(composePath, source);
+    const readResult = await readComposeDocument(cwd, "compose.yaml");
+    expect(readResult.isOk()).toBe(true);
+    if (readResult.isErr()) {
+      return;
+    }
+
+    const writeResult = await writeComposeDocument(
+      cwd,
+      "compose.yaml",
+      { services: { app: { image: "new/app" } } },
+      readResult.value.revision,
+      createFileSystem({
+        rename: () => Promise.reject(new Error("rename failed")),
+      })
+    );
+
+    expect(writeResult.isErr()).toBe(true);
+    expect((await readFile(composePath, "utf8")).toString()).toBe(source);
+    expect(
+      (await readdir(cwd)).filter((name) => name.startsWith(".compose.yaml."))
+    ).toEqual([]);
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+});
+
 async function readComposeFailure(source: string): Promise<{
   contents: string;
   error: ComposeFileFailure | undefined;
@@ -337,6 +670,23 @@ async function readComposeFailure(source: string): Promise<{
 
 function createTempDirectory(): Promise<string> {
   return mkdtemp(join(tmpdir(), "ayanokoji-compose-adapter-"));
+}
+
+function createFileSystem(
+  overrides: Partial<ComposeFileSystem> = {}
+): ComposeFileSystem {
+  return {
+    chmod,
+    link,
+    readFile: async (path) => (await readFile(path, "utf8")).toString(),
+    rename,
+    stat: lstat,
+    unlink,
+    writeFile: async (path, data, options) => {
+      await writeFile(path, data, options);
+    },
+    ...overrides,
+  };
 }
 
 async function removeTempDirectory(cwd: string): Promise<void> {

--- a/packages/cli/src/commands/docker/helpers/compose-file-adapter.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-file-adapter.ts
@@ -1,9 +1,15 @@
+import { createHash, randomUUID } from "node:crypto";
 import {
+  chmod as chmodOnDisk,
+  link as linkOnDisk,
   readFile as readFileFromDisk,
-  stat as statOnDisk,
+  rename as renameOnDisk,
+  lstat as statOnDisk,
+  unlink as unlinkOnDisk,
+  writeFile as writeFileToDisk,
 } from "node:fs/promises";
 import { join } from "node:path";
-import { parseAllDocuments } from "yaml";
+import { parseAllDocuments, stringify } from "yaml";
 import { Err, Ok } from "~/utils/result";
 import type { ComposeDocument } from "./compose-document";
 
@@ -18,11 +24,43 @@ export type ComposeFileName = (typeof COMPOSE_FILE_NAMES)[number];
 
 export interface ComposeFileStats {
   isFile(): boolean;
+  isSymbolicLink?(): boolean;
+  dev?: number;
+  ino?: number;
+  mode?: number;
+  mtimeMs?: number;
+  size?: number;
 }
 
-export interface ComposeFileSystem {
+export interface ComposeFileReader {
   stat(path: string): Promise<ComposeFileStats>;
   readFile(path: string): Promise<string>;
+}
+
+export interface ComposeFileSystem extends ComposeFileReader {
+  chmod(path: string, mode: number): Promise<void>;
+  link(existingPath: string, newPath: string): Promise<void>;
+  rename(oldPath: string, newPath: string): Promise<void>;
+  unlink(path: string): Promise<void>;
+  writeFile(
+    path: string,
+    data: string,
+    options?: { flag?: string; mode?: number }
+  ): Promise<void>;
+}
+
+export interface ComposeFileRevision {
+  readonly contentHash: string;
+  readonly dev?: number;
+  readonly ino?: number;
+  readonly mode?: number;
+  readonly mtimeMs?: number;
+  readonly size?: number;
+}
+
+export interface ComposeDocumentSnapshot {
+  document: ComposeDocument;
+  revision: ComposeFileRevision;
 }
 
 export type ComposeFileFailure =
@@ -52,19 +90,46 @@ export type ComposeFileFailure =
       fileName: ComposeFileName;
       field: "root" | "services" | "volumes";
       serviceName?: string;
+    }
+  | {
+      kind: "symlinked-document";
+      fileName: ComposeFileName;
+    }
+  | {
+      kind: "stale-document";
+      fileName: ComposeFileName;
+    }
+  | {
+      kind: "creation-conflict";
+      fileName: ComposeFileName;
+    }
+  | {
+      kind: "serialization-failure";
+      fileName: ComposeFileName;
+    }
+  | {
+      kind: "write-failure";
+      fileName: ComposeFileName;
     };
 
 const nodeFileSystem: ComposeFileSystem = {
+  chmod: (path, mode) => chmodOnDisk(path, mode),
+  link: (existingPath, newPath) => linkOnDisk(existingPath, newPath),
   readFile: async (path) => {
     const contents = await readFileFromDisk(path);
     return contents.toString("utf8");
   },
+  rename: (oldPath, newPath) => renameOnDisk(oldPath, newPath),
   stat: (path) => statOnDisk(path),
+  unlink: (path) => unlinkOnDisk(path),
+  writeFile: async (path, data, options) => {
+    await writeFileToDisk(path, data, options);
+  },
 };
 
 export async function discoverComposeFiles(
   cwd: string,
-  fileSystem: ComposeFileSystem = nodeFileSystem
+  fileSystem: ComposeFileReader = nodeFileSystem
 ): Promise<
   | Ok<ComposeFileName[], ComposeFileFailure>
   | Err<ComposeFileName[], ComposeFileFailure>
@@ -74,6 +139,10 @@ export async function discoverComposeFiles(
   for (const fileName of COMPOSE_FILE_NAMES) {
     try {
       const stats = await fileSystem.stat(join(cwd, fileName));
+      if (isSymbolicLink(stats)) {
+        return new Err({ kind: "symlinked-document", fileName });
+      }
+
       if (stats.isFile()) {
         candidates.push(fileName);
       }
@@ -92,21 +161,59 @@ export async function discoverComposeFiles(
 export async function readComposeDocument(
   cwd: string,
   fileName: ComposeFileName,
-  fileSystem: ComposeFileSystem = nodeFileSystem
+  fileSystem: ComposeFileReader = nodeFileSystem
 ): Promise<
-  | Ok<ComposeDocument, ComposeFileFailure>
-  | Err<ComposeDocument, ComposeFileFailure>
+  | Ok<ComposeDocumentSnapshot, ComposeFileFailure>
+  | Err<ComposeDocumentSnapshot, ComposeFileFailure>
 > {
-  let source: string;
+  const path = join(cwd, fileName);
+  let initialStats: ComposeFileStats;
 
   try {
-    source = await fileSystem.readFile(join(cwd, fileName));
+    initialStats = await fileSystem.stat(path);
   } catch (error) {
     if (isMissingFileError(error)) {
       return new Err({ kind: "missing-document", fileName });
     }
 
     return new Err({ kind: "read-failure", fileName });
+  }
+
+  if (isSymbolicLink(initialStats)) {
+    return new Err({ kind: "symlinked-document", fileName });
+  }
+
+  if (!initialStats.isFile()) {
+    return new Err({ kind: "read-failure", fileName });
+  }
+
+  let source: string;
+
+  try {
+    source = await fileSystem.readFile(path);
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return new Err({ kind: "missing-document", fileName });
+    }
+
+    return new Err({ kind: "read-failure", fileName });
+  }
+
+  let finalStats: ComposeFileStats;
+  try {
+    finalStats = await fileSystem.stat(path);
+  } catch {
+    return new Err({ kind: "stale-document", fileName });
+  }
+
+  if (isSymbolicLink(finalStats)) {
+    return new Err({ kind: "symlinked-document", fileName });
+  }
+
+  if (
+    !(finalStats.isFile() && sameRevisionMetadata(initialStats, finalStats))
+  ) {
+    return new Err({ kind: "stale-document", fileName });
   }
 
   let documents: ReturnType<typeof parseAllDocuments>;
@@ -170,7 +277,124 @@ export async function readComposeDocument(
     });
   }
 
-  return validateComposeDocument(value, fileName);
+  const validationResult = validateComposeDocument(value, fileName);
+  if (validationResult.isErr()) {
+    return new Err(validationResult.error);
+  }
+
+  return new Ok({
+    document: validationResult.value,
+    revision: createFileRevision(finalStats, source),
+  });
+}
+
+export async function writeComposeDocument(
+  cwd: string,
+  fileName: ComposeFileName,
+  document: ComposeDocument,
+  revision?: ComposeFileRevision,
+  fileSystem: ComposeFileSystem = nodeFileSystem
+): Promise<Ok<null, ComposeFileFailure> | Err<null, ComposeFileFailure>> {
+  const path = join(cwd, fileName);
+  const expectedRevision = revision;
+  let targetStats: ComposeFileStats | undefined;
+
+  try {
+    targetStats = await fileSystem.stat(path);
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      return new Err({ kind: "write-failure", fileName });
+    }
+  }
+
+  if (targetStats) {
+    if (isSymbolicLink(targetStats)) {
+      return new Err({ kind: "symlinked-document", fileName });
+    }
+
+    if (!expectedRevision) {
+      return new Err({ kind: "creation-conflict", fileName });
+    }
+
+    const revisionFailure = await verifyRevision(
+      path,
+      fileName,
+      expectedRevision,
+      fileSystem,
+      targetStats
+    );
+    if (revisionFailure) {
+      return new Err(revisionFailure);
+    }
+  } else if (revision) {
+    return new Err({ kind: "stale-document", fileName });
+  }
+
+  let serializedDocument: string;
+  try {
+    serializedDocument = stringify(document, { indent: 2 });
+  } catch {
+    return new Err({ kind: "serialization-failure", fileName });
+  }
+
+  const temporaryPath = join(cwd, `.${fileName}.${randomUUID()}.tmp`);
+  let temporaryFileExists = false;
+
+  try {
+    await fileSystem.writeFile(temporaryPath, serializedDocument, {
+      flag: "wx",
+    });
+    temporaryFileExists = true;
+
+    if (targetStats?.mode !== undefined) {
+      await fileSystem.chmod(temporaryPath, targetStats.mode % 0o1_0000);
+    }
+
+    if (targetStats) {
+      if (!expectedRevision) {
+        return new Err({ kind: "stale-document", fileName });
+      }
+
+      const revisionFailure = await verifyRevision(
+        path,
+        fileName,
+        expectedRevision,
+        fileSystem
+      );
+      if (revisionFailure) {
+        return new Err(revisionFailure);
+      }
+
+      await fileSystem.rename(temporaryPath, path);
+      temporaryFileExists = false;
+    } else {
+      try {
+        await fileSystem.link(temporaryPath, path);
+      } catch (error) {
+        if (isExistingFileError(error)) {
+          const failure = await getExistingTargetFailure(
+            path,
+            fileName,
+            fileSystem
+          );
+          return new Err(failure);
+        }
+
+        throw error;
+      }
+
+      await fileSystem.unlink(temporaryPath);
+      temporaryFileExists = false;
+    }
+
+    return new Ok(null);
+  } catch {
+    return new Err({ kind: "write-failure", fileName });
+  } finally {
+    if (temporaryFileExists) {
+      await removeTemporaryFile(temporaryPath, fileSystem);
+    }
+  }
 }
 
 function validateComposeDocument(
@@ -209,6 +433,119 @@ function validateComposeDocument(
 
 function isMissingFileError(error: unknown): boolean {
   return isRecord(error) && error.code === "ENOENT";
+}
+
+function isExistingFileError(error: unknown): boolean {
+  return isRecord(error) && error.code === "EEXIST";
+}
+
+function isSymbolicLink(stats: ComposeFileStats): boolean {
+  return stats.isSymbolicLink?.() ?? false;
+}
+
+function createFileRevision(
+  stats: ComposeFileStats,
+  source: string
+): ComposeFileRevision {
+  return {
+    contentHash: createHash("sha256").update(source).digest("hex"),
+    dev: stats.dev,
+    ino: stats.ino,
+    mode: stats.mode,
+    mtimeMs: stats.mtimeMs,
+    size: stats.size,
+  };
+}
+
+async function verifyRevision(
+  path: string,
+  fileName: ComposeFileName,
+  revision: ComposeFileRevision,
+  fileSystem: ComposeFileReader,
+  knownStats?: ComposeFileStats
+): Promise<ComposeFileFailure | undefined> {
+  let stats = knownStats;
+
+  if (!stats) {
+    try {
+      stats = await fileSystem.stat(path);
+    } catch {
+      return { kind: "stale-document", fileName };
+    }
+  }
+
+  if (isSymbolicLink(stats)) {
+    return { kind: "symlinked-document", fileName };
+  }
+
+  if (!(stats.isFile() && sameRevisionMetadata(stats, revision))) {
+    return { kind: "stale-document", fileName };
+  }
+
+  let source: string;
+  try {
+    source = await fileSystem.readFile(path);
+  } catch {
+    return { kind: "read-failure", fileName };
+  }
+
+  return sameRevision(revision, createFileRevision(stats, source))
+    ? undefined
+    : { kind: "stale-document", fileName };
+}
+
+function sameRevisionMetadata(
+  first: Pick<ComposeFileStats, "dev" | "ino" | "mode" | "mtimeMs" | "size">,
+  second: Pick<ComposeFileStats, "dev" | "ino" | "mode" | "mtimeMs" | "size">
+): boolean {
+  return (
+    first.dev === second.dev &&
+    first.ino === second.ino &&
+    first.mode === second.mode &&
+    first.mtimeMs === second.mtimeMs &&
+    first.size === second.size
+  );
+}
+
+function sameRevision(
+  first: ComposeFileRevision,
+  second: ComposeFileRevision
+): boolean {
+  return (
+    first.contentHash === second.contentHash &&
+    sameRevisionMetadata(first, second)
+  );
+}
+
+async function getExistingTargetFailure(
+  path: string,
+  fileName: ComposeFileName,
+  fileSystem: ComposeFileReader
+): Promise<
+  Extract<
+    ComposeFileFailure,
+    { kind: "symlinked-document" | "creation-conflict" }
+  >
+> {
+  try {
+    const stats = await fileSystem.stat(path);
+    return isSymbolicLink(stats)
+      ? { kind: "symlinked-document", fileName }
+      : { kind: "creation-conflict", fileName };
+  } catch {
+    return { kind: "creation-conflict", fileName };
+  }
+}
+
+async function removeTemporaryFile(
+  path: string,
+  fileSystem: ComposeFileSystem
+): Promise<void> {
+  try {
+    await fileSystem.unlink(path);
+  } catch {
+    // Preserve the original file even when temporary-file cleanup fails.
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/commands/docker/helpers/format-compose-file-failure.ts
+++ b/packages/cli/src/commands/docker/helpers/format-compose-file-failure.ts
@@ -16,6 +16,16 @@ export function formatComposeFileFailure(failure: ComposeFileFailure): string {
         failure.field,
         failure.serviceName
       );
+    case "symlinked-document":
+      return `Docker Compose path must not be a symbolic link: ${failure.fileName}`;
+    case "stale-document":
+      return `Docker Compose file changed during the operation; rerun the command: ${failure.fileName}`;
+    case "creation-conflict":
+      return `Docker Compose file was created during the operation: ${failure.fileName}`;
+    case "serialization-failure":
+      return `Failed to serialize Docker Compose file: ${failure.fileName}`;
+    case "write-failure":
+      return `Failed to write Docker Compose file: ${failure.fileName}`;
     default:
       return "Docker Compose file operation failed.";
   }

--- a/packages/cli/src/commands/docker/helpers/init-docker.ts
+++ b/packages/cli/src/commands/docker/helpers/init-docker.ts
@@ -1,4 +1,3 @@
-import { writeFile } from "~/utils/fs";
 import { enhancedMultiselect, enhancedSelect } from "~/utils/prompts";
 import { Err, Ok } from "~/utils/result";
 import { type DatabaseImageConfig, DOCKER_DATABASES } from "../databases";
@@ -12,8 +11,10 @@ import {
 import {
   COMPOSE_FILE_NAMES,
   type ComposeFileName,
+  type ComposeFileRevision,
   discoverComposeFiles,
   readComposeDocument,
+  writeComposeDocument,
 } from "./compose-file-adapter";
 import { formatComposeFileFailure } from "./format-compose-file-failure";
 import type { ConnectionConfig } from "./generate-connection-string";
@@ -29,10 +30,10 @@ export interface InitDockerResult {
 
 export async function initDocker(options: InitDockerProps) {
   const discoveryResult = await discoverComposeFiles(options.cwd);
-  const { stringify } = await import("yaml");
 
   let config: ComposeDocument = {};
   let fileName: ComposeFileName;
+  let revision: ComposeFileRevision | undefined;
 
   if (discoveryResult.isErr()) {
     return new Err(formatComposeFileFailure(discoveryResult.error));
@@ -71,7 +72,8 @@ export async function initDocker(options: InitDockerProps) {
       return new Err(formatComposeFileFailure(fileResult.error));
     }
 
-    config = fileResult.value;
+    config = fileResult.value.document;
+    revision = fileResult.value.revision;
   }
 
   const existingServices = getServiceNames(config);
@@ -117,19 +119,14 @@ export async function initDocker(options: InitDockerProps) {
     return new Err(formatComposeMutationFailure(mutationResult.error));
   }
 
-  let serializedConfig: string;
-  try {
-    serializedConfig = stringify(mutationResult.value, null, 2);
-  } catch {
-    return new Err(`Failed to serialize Docker Compose file: ${fileName}`);
-  }
-
-  const writeResult = await writeFile(
-    `${options.cwd}/${fileName}`,
-    serializedConfig
+  const writeResult = await writeComposeDocument(
+    options.cwd,
+    fileName,
+    mutationResult.value,
+    revision
   );
   if (writeResult.isErr()) {
-    return new Err(`Failed to write Docker Compose file: ${fileName}`);
+    return new Err(formatComposeFileFailure(writeResult.error));
   }
 
   return new Ok({ imageConfigs, connectionConfigs });

--- a/packages/cli/src/commands/docker/remove.ts
+++ b/packages/cli/src/commands/docker/remove.ts
@@ -1,5 +1,5 @@
 import { Command } from "commander";
-import { access, writeFile } from "~/utils/fs";
+import { access } from "~/utils/fs";
 import { handleError } from "~/utils/handle-error";
 import { logger } from "~/utils/logger";
 import {
@@ -18,6 +18,7 @@ import {
   type ComposeFileName,
   discoverComposeFiles,
   readComposeDocument,
+  writeComposeDocument,
 } from "./helpers/compose-file-adapter";
 import { readEnvFile, writeEnvFile } from "./helpers/env-file";
 import { formatComposeFileFailure } from "./helpers/format-compose-file-failure";
@@ -43,8 +44,6 @@ export const remove = new Command()
     if (optionsResult.isErr()) {
       handleError(optionsResult.error);
     }
-
-    const { stringify } = await import("yaml");
 
     const discoveryResult = await discoverComposeFiles(options.cwd);
 
@@ -83,7 +82,7 @@ export const remove = new Command()
       return;
     }
 
-    const config: ComposeDocument = fileResult.value;
+    const config: ComposeDocument = fileResult.value.document;
     const servicesResult = getRemovableServiceNames(config);
 
     if (servicesResult.isErr()) {
@@ -110,21 +109,14 @@ export const remove = new Command()
       return;
     }
 
-    // Write updated compose file
-    let serializedConfig: string;
-    try {
-      serializedConfig = stringify(mutationResult.value, null, 2);
-    } catch {
-      handleError(`Failed to serialize ${existingFile}`);
-      return;
-    }
-
-    const writeResult = await writeFile(
-      `${options.cwd}/${existingFile}`,
-      serializedConfig
+    const writeResult = await writeComposeDocument(
+      options.cwd,
+      existingFile,
+      mutationResult.value,
+      fileResult.value.revision
     );
     if (writeResult.isErr()) {
-      handleError(`Failed to write ${existingFile}`);
+      handleError(formatComposeFileFailure(writeResult.error));
       return;
     }
 


### PR DESCRIPTION
Route Docker mutations through a safe file adapter that preserves permissions, rejects symlinks and stale revisions, and creates new files exclusively.
Closes #20

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>