### PR TITLE
chore(verification): add boundary checks

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Generate docs artifacts
+        run: pnpm run docs:generate
+
       - name: Lint
         run: pnpm run lint
 
@@ -45,6 +48,9 @@ jobs:
 
       - name: Build
         run: pnpm run build
+
+      - name: Verify public boundary
+        run: pnpm run verify
 
       - name: Check release status
         run: |

--- a/.oxlintrc.jsonc
+++ b/.oxlintrc.jsonc
@@ -19,9 +19,6 @@
     "es2025": true,
     "node": true,
   },
-  "globals": {
-    "Bun": "readonly",
-  },
   "options": {
     "typeAware": true,
     "typeCheck": true,

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pnpm lint
 pnpm format
 pnpm type-check
 pnpm build
+pnpm verify
 pnpm exec changeset status
 ```
 

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,9 +7,10 @@
     "dev": "next dev",
     "start": "next start",
     "postinstall": "fumadocs-mdx",
-    "type-check": "next typegen && fumadocs-mdx && oxlint . --type-aware --type-check",
-    "lint": "oxlint .",
-    "lint:fix": "oxlint . --fix",
+    "generate": "next typegen && fumadocs-mdx",
+    "type-check": "pnpm run generate && oxlint . --type-aware --type-check",
+    "lint": "pnpm run generate && oxlint .",
+    "lint:fix": "pnpm run generate && oxlint . --fix",
     "format": "oxfmt --check .",
     "format:fix": "oxfmt --write ."
   },

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",
     "clean": "rimraf --glob \"{apps,packages}/*/{node_modules,dist}\" \"node_modules\" \".turbo\"",
-    "lint": "pnpm --filter docs exec next typegen && oxlint .",
-    "lint:fix": "pnpm --filter docs exec next typegen && oxlint . --fix",
+    "docs:generate": "pnpm --filter docs generate",
+    "lint": "pnpm run docs:generate && oxlint .",
+    "lint:fix": "pnpm run docs:generate && oxlint . --fix",
     "format": "oxfmt --check .",
     "format:fix": "oxfmt --write .",
     "test": "turbo run test",
@@ -31,6 +32,9 @@
     "cli": "pnpm --filter ayanokoji",
     "docs": "pnpm --filter docs",
     "release": "pnpm run build && pnpm exec changeset publish",
+    "audit:internal": "node scripts/audit-internal-toolchain.mjs",
+    "verify:cli": "node scripts/verify-cli-boundary.mjs",
+    "verify": "pnpm run audit:internal && pnpm run verify:cli",
     "prepare": "lefthook install"
   },
   "devDependencies": {

--- a/scripts/audit-internal-toolchain.mjs
+++ b/scripts/audit-internal-toolchain.mjs
@@ -1,0 +1,131 @@
+import { execFileSync } from "node:child_process";
+import { lstatSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIRECTORY = fileURLToPath(new URL("../", import.meta.url));
+const TOOL_REFERENCE_PATTERN =
+  /\b(?:bun|biome|ultracite)\b|@biomejs\/biome|bun:/giu;
+const BINARY_FILE_PATTERN =
+  /\.(?:gif|ico|jpeg|jpg|png|svg|webp|woff2?|eot|ttf|mp[34]|zip|tgz)$/iu;
+
+const intentionalReferenceCategories = [
+  {
+    label: "public CLI behavior",
+    matches: (filePath) =>
+      filePath.startsWith("packages/cli/src/") &&
+      !filePath.includes(".test.") &&
+      !filePath.includes(".spec."),
+  },
+  {
+    label: "public documentation",
+    matches: (filePath) =>
+      filePath.startsWith("apps/docs/src/content/docs/") ||
+      [
+        "apps/docs/src/components/ui/icons.tsx",
+        "apps/docs/src/config/site.ts",
+      ].includes(filePath),
+  },
+  {
+    label: "historical or domain documentation",
+    matches: (filePath) =>
+      filePath.startsWith("docs/") ||
+      ["CONTEXT.md", "packages/cli/CHANGELOG.md"].includes(filePath),
+  },
+  {
+    label: "contributor documentation",
+    matches: (filePath) => ["AGENTS.md", "README.md"].includes(filePath),
+  },
+  {
+    label: "legacy-tool rejection guardrails",
+    matches: (filePath) =>
+      [
+        ".claude/hooks/enforce-pkg-manager.sh",
+        ".opencode/plugins/guardrails.js",
+      ].includes(filePath),
+  },
+  {
+    label: "audit policy",
+    matches: (filePath) =>
+      [
+        "scripts/audit-internal-toolchain.mjs",
+        "scripts/verify-cli-boundary.mjs",
+      ].includes(filePath),
+  },
+];
+
+function getReferenceCategory(filePath) {
+  return (
+    intentionalReferenceCategories.find((category) =>
+      category.matches(filePath)
+    )?.label ?? null
+  );
+}
+
+function getTrackedFiles() {
+  return execFileSync("git", ["ls-files", "-z"], {
+    cwd: ROOT_DIRECTORY,
+    encoding: "utf8",
+  })
+    .split("\0")
+    .filter((filePath) => filePath.length > 0);
+}
+
+function getLineNumber(contents, index) {
+  return contents.slice(0, index).split("\n").length;
+}
+
+const intentionalReferences = new Map();
+const violations = [];
+
+for (const filePath of getTrackedFiles()) {
+  if (BINARY_FILE_PATTERN.test(filePath)) {
+    continue;
+  }
+
+  if (lstatSync(join(ROOT_DIRECTORY, filePath)).isSymbolicLink()) {
+    continue;
+  }
+
+  const contents = readFileSync(join(ROOT_DIRECTORY, filePath), "utf8");
+  const category = getReferenceCategory(filePath);
+
+  for (const match of contents.matchAll(TOOL_REFERENCE_PATTERN)) {
+    const reference = {
+      filePath,
+      line: getLineNumber(contents, match.index ?? 0),
+      value: match[0],
+    };
+
+    if (category === null) {
+      violations.push(reference);
+      continue;
+    }
+
+    const references = intentionalReferences.get(category) ?? [];
+    references.push(reference);
+    intentionalReferences.set(category, references);
+  }
+}
+
+if (violations.length > 0) {
+  console.error("Unexpected internal toolchain references found:");
+  for (const violation of violations) {
+    console.error(
+      `- ${violation.filePath}:${violation.line} contains ${violation.value}`
+    );
+  }
+  process.exitCode = 1;
+} else {
+  console.log("Internal toolchain audit passed.");
+}
+
+if (intentionalReferences.size > 0) {
+  console.log("Intentional legacy-tool references:");
+  for (const [category, references] of intentionalReferences) {
+    const locations = references.map(
+      (reference) => `${reference.filePath}:${reference.line}`
+    );
+    console.log(`- ${category}: ${[...new Set(locations)].join(", ")}`);
+  }
+}

--- a/scripts/verify-cli-boundary.mjs
+++ b/scripts/verify-cli-boundary.mjs
@@ -1,0 +1,220 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIRECTORY = fileURLToPath(new URL("../", import.meta.url));
+const CLI_DIRECTORY = join(ROOT_DIRECTORY, "packages/cli");
+const CLI_MANIFEST_PATH = join(CLI_DIRECTORY, "package.json");
+const CLI_MANIFEST = JSON.parse(readFileSync(CLI_MANIFEST_PATH, "utf8"));
+const DEVELOPMENT_ONLY_PACKAGES = new Set([
+  "@biomejs/biome",
+  "@typescript/native",
+  "oxfmt",
+  "oxlint",
+  "oxlint-tsgolint",
+  "tsdown",
+  "typescript",
+  "ultracite",
+  "vitest",
+]);
+const EXPECTED_RUNTIME_DEPENDENCIES = [
+  "@antfu/ni",
+  "@clack/prompts",
+  "commander",
+  "nano-spawn",
+  "picocolors",
+  "yaml",
+  "zod",
+];
+const PUBLIC_COMMANDS = [
+  "biome",
+  "docker",
+  "drizzle",
+  "gitignore",
+  "prisma",
+  "secret",
+  "typescript",
+];
+const PUBLIC_MARKERS = [
+  {
+    filePath: "src/commands/biome/index.ts",
+    markers: ['new Command("biome")'],
+  },
+  {
+    filePath: "src/commands/drizzle/databases/sqlite.ts",
+    markers: ['value: "bun-sqlite"', 'from "bun:sqlite"'],
+  },
+  {
+    filePath: "src/utils/get-package-manager.ts",
+    markers: ['"bun"'],
+  },
+  {
+    filePath: "src/commands/typescript/helpers/get-tsconfig-file.ts",
+    markers: ['target: "es2022"', 'moduleResolution: "Bundler"'],
+  },
+  {
+    filePath: "src/commands/drizzle/helpers/create-drizzle-scripts.ts",
+    markers: ["  bun: {", '"db:generate": "bun run drizzle generate"'],
+  },
+];
+const BUNDLE_REFERENCE_PATTERN =
+  /\b(?:oxfmt|oxlint|tsdown|ultracite|vitest)\b|@typescript\/native|oxlint-tsgolint/giu;
+const failures = [];
+
+function assert(condition, message) {
+  if (!condition) {
+    failures.push(message);
+  }
+}
+
+function getSortedKeys(value) {
+  return Object.keys(value ?? {}).sort();
+}
+
+function getJsonValue(value) {
+  return JSON.stringify(value);
+}
+
+function readCliFile(filePath) {
+  return readFileSync(join(CLI_DIRECTORY, filePath), "utf8");
+}
+
+function parsePackResult(output) {
+  const jsonStart = output.indexOf("{");
+  return JSON.parse(output.slice(jsonStart));
+}
+
+assert(
+  CLI_MANIFEST.private === false,
+  "The CLI package must remain publishable."
+);
+assert(
+  CLI_MANIFEST.main === "./dist/index.mjs",
+  "The CLI main entry point changed."
+);
+assert(
+  CLI_MANIFEST.exports === "./dist/index.mjs",
+  "The CLI exports entry point changed."
+);
+assert(
+  CLI_MANIFEST.module === "./dist/index.mjs",
+  "The CLI module entry point changed."
+);
+assert(
+  CLI_MANIFEST.bin === "./dist/index.mjs",
+  "The CLI binary entry point changed."
+);
+assert(
+  getJsonValue(CLI_MANIFEST.files) === getJsonValue(["dist"]),
+  "The CLI published file boundary changed."
+);
+assert(
+  CLI_MANIFEST.sideEffects === false,
+  "The CLI sideEffects contract changed."
+);
+
+const runtimeDependencies = getSortedKeys(CLI_MANIFEST.dependencies);
+const expectedRuntimeDependencies = [...EXPECTED_RUNTIME_DEPENDENCIES].sort();
+assert(
+  getJsonValue(runtimeDependencies) ===
+    getJsonValue(expectedRuntimeDependencies),
+  `The CLI runtime dependencies changed: ${runtimeDependencies.join(", ")}`
+);
+
+for (const dependency of runtimeDependencies) {
+  assert(
+    !DEVELOPMENT_ONLY_PACKAGES.has(dependency),
+    `Development-only package ${dependency} entered CLI runtime dependencies.`
+  );
+}
+
+for (const { filePath, markers } of PUBLIC_MARKERS) {
+  const contents = readCliFile(filePath);
+  for (const marker of markers) {
+    assert(
+      contents.includes(marker),
+      `Public CLI marker ${JSON.stringify(marker)} is missing from ${filePath}.`
+    );
+  }
+}
+
+const cliEntryPoint = join(CLI_DIRECTORY, CLI_MANIFEST.main);
+try {
+  const help = execFileSync(process.execPath, [cliEntryPoint, "--help"], {
+    cwd: ROOT_DIRECTORY,
+    encoding: "utf8",
+  });
+  for (const command of PUBLIC_COMMANDS) {
+    assert(
+      help.includes(`\n  ${command}`),
+      `Public CLI command ${command} is missing from the built command list.`
+    );
+  }
+} catch (error) {
+  failures.push(
+    `The built CLI could not be invoked: ${
+      error instanceof Error ? error.message : String(error)
+    }`
+  );
+}
+
+const distFiles = [];
+try {
+  const packResult = parsePackResult(
+    execFileSync(
+      "pnpm",
+      ["--filter", "ayanokoji", "pack", "--dry-run", "--json"],
+      {
+        cwd: ROOT_DIRECTORY,
+        encoding: "utf8",
+      }
+    )
+  );
+  const publishedFiles = packResult.files.map(({ path }) => path);
+  const unexpectedFiles = publishedFiles.filter(
+    (filePath) =>
+      !filePath.startsWith("dist/") &&
+      !["LICENSE.md", "package.json"].includes(filePath)
+  );
+  assert(
+    unexpectedFiles.length === 0,
+    `Unexpected files would be packed: ${unexpectedFiles.join(", ")}`
+  );
+  assert(
+    publishedFiles.includes("dist/index.mjs"),
+    "The built CLI entry point is absent from the package."
+  );
+  distFiles.push(
+    ...publishedFiles
+      .filter((filePath) => filePath.startsWith("dist/"))
+      .map((filePath) => join(CLI_DIRECTORY, filePath))
+  );
+} catch (error) {
+  failures.push(
+    `The CLI package could not be inspected: ${
+      error instanceof Error ? error.message : String(error)
+    }`
+  );
+}
+
+for (const filePath of distFiles) {
+  const contents = readFileSync(filePath, "utf8");
+  for (const match of contents.matchAll(BUNDLE_REFERENCE_PATTERN)) {
+    failures.push(
+      `Development-only bundle reference ${match[0]} found in ${filePath}.`
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error("CLI public-boundary verification failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exitCode = 1;
+} else {
+  console.log(
+    `CLI public-boundary verification passed (${distFiles.length} packed bundle files).`
+  );
+}


### PR DESCRIPTION
Generate framework types before type-aware linting and audit the internal toolchain and packed CLI surface.\n\nCloses #36

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>