### PR TITLE
chore(lint): enable unicorn object default rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -9,8 +9,7 @@ export default defineConfig({
     core,
     react,
     next,
-    // TODO: Enable it later and fix all the issues
-    // 77 errors
+    // Deferred: 77 errors
     // vitest,
   ],
   ignorePatterns: [
@@ -32,64 +31,62 @@ export default defineConfig({
       },
     ],
 
-    // TODO: Enable it later and fix all the issues
-    // 3 errors
+    // Deferred: 3 errors
     complexity: "off",
-    // 5 errors
+    // Deferred: 5 errors
     "no-warning-comments": "off",
-    // 4 errors
+    // Deferred: 4 errors
     "no-await-in-loop": "off",
-    // 118 errors
+    // Deferred: 118 errors
     "no-use-before-define": "off",
-    // 3 errors
+    // Deferred: 3 errors
     "typescript/no-dynamic-delete": "off",
-    // 6 errors
+    // Deferred: 6 errors
     "prefer-destructuring": "off",
-    // 6 errors
+    // Deferred: 6 errors
     "require-unicode-regexp": "off",
-    // 9 errors
+    // Deferred: 9 errors
     "no-shadow": "off",
-    // 6 errors
+    // Deferred: 6 errors
     "prefer-named-capture-group": "off",
-    // 30 errors
+    // Deferred: 30 errors
     "unicorn/no-await-expression-member": "off",
-    // 20 errors
+    // Deferred: 20 errors
     "require-await": "off",
-    // 1 errors
+    // Deferred: 1 error
     "oxc/branches-sharing-code": "off",
-    // 24 errors
+    // Deferred: 24 errors
     "typescript/no-unnecessary-type-conversion": "off",
-    // 12 errors
+    // Deferred: 12 errors
     "typescript/strict-boolean-expressions": "off",
-    // 7 errors
+    // Deferred: 7 errors
     "typescript/no-unsafe-type-assertion": "off",
-    // 3 errors
+    // Deferred: 3 errors
     "typescript/no-deprecated": "off",
-    // 13 errors
+    // Deferred: 13 errors
     "typescript/consistent-return": "off",
-    // 2 errors
+    // Deferred: 2 errors
     "typescript/no-unsafe-assignment": "off",
-    // 3 errors
+    // Deferred: 3 errors
     "typescript/no-unsafe-member-access": "off",
-    // 2 errors
+    // Deferred: 2 errors
     "typescript/switch-exhaustiveness-check": "off",
-    // 3 errors
+    // Deferred: 3 errors
     "typescript/prefer-nullish-coalescing": "off",
-    // 11 errors
+    // Deferred: 11 errors
     "typescript/method-signature-style": "off",
-    // 5 errors
+    // Deferred: 5 errors
     "unicorn/import-style": "off",
-    // 2 errors
+    // Deferred: 2 errors
     "promise/prefer-await-to-callbacks": "off",
-    // 3 errors
+    // Deferred: 3 errors
     "unicorn/no-array-reduce": "off",
-    // 1 errors
-    "unicorn/no-object-as-default-parameter": "off",
-    // 1 errors
+    "unicorn/no-object-as-default-parameter": "error",
+    // Deferred: 1 error
     "max-classes-per-file": "off",
-    // 2 errors
+    // Deferred: 2 errors
     "typescript/parameter-properties": "off",
-    // 4 errors
+    // Deferred: 4 errors
     "class-methods-use-this": "off",
   },
   options: {

--- a/packages/cli/src/utils/get-package-manager.ts
+++ b/packages/cli/src/utils/get-package-manager.ts
@@ -4,9 +4,7 @@ export type PackageManager = "yarn" | "pnpm" | "bun" | "npm" | "deno";
 
 export async function getPackageManager(
   targetDir: string,
-  { withFallback }: { withFallback?: boolean } = {
-    withFallback: false,
-  }
+  { withFallback = false }: { withFallback?: boolean } = {}
 ): Promise<PackageManager> {
   const packageManager = await detect({ cwd: targetDir, programmatic: true });
 


### PR DESCRIPTION
Preserve package-manager fallback options with destructuring defaults and normalize deferred lint baselines.

Closes #45

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>