### PR TITLE
chore(lint): enable method signature style

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -73,8 +73,7 @@ export default defineConfig({
     "typescript/switch-exhaustiveness-check": "off",
     // Deferred: 3 errors
     "typescript/prefer-nullish-coalescing": "off",
-    // Deferred: 11 errors
-    "typescript/method-signature-style": "off",
+    "typescript/method-signature-style": ["error", "property"],
     // Deferred: 5 errors
     "unicorn/import-style": "off",
     // Deferred: 2 errors

--- a/packages/cli/src/commands/docker/helpers/compose-file-adapter.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-file-adapter.ts
@@ -26,8 +26,8 @@ export const COMPOSE_FILE_NAMES = [
 export type ComposeFileName = (typeof COMPOSE_FILE_NAMES)[number];
 
 export interface ComposeFileStats {
-  isFile(): boolean;
-  isSymbolicLink?(): boolean;
+  isFile: () => boolean;
+  isSymbolicLink?: () => boolean;
   dev?: number;
   ino?: number;
   mode?: number;
@@ -36,20 +36,20 @@ export interface ComposeFileStats {
 }
 
 export interface ComposeFileReader {
-  stat(path: string): Promise<ComposeFileStats>;
-  readFile(path: string): Promise<string>;
+  stat: (path: string) => Promise<ComposeFileStats>;
+  readFile: (path: string) => Promise<string>;
 }
 
 export interface ComposeFileSystem extends ComposeFileReader {
-  chmod(path: string, mode: number): Promise<void>;
-  link(existingPath: string, newPath: string): Promise<void>;
-  rename(oldPath: string, newPath: string): Promise<void>;
-  unlink(path: string): Promise<void>;
-  writeFile(
+  chmod: (path: string, mode: number) => Promise<void>;
+  link: (existingPath: string, newPath: string) => Promise<void>;
+  rename: (oldPath: string, newPath: string) => Promise<void>;
+  unlink: (path: string) => Promise<void>;
+  writeFile: (
     path: string,
     data: string,
     options?: { flag?: string; mode?: number }
-  ): Promise<void>;
+  ) => Promise<void>;
 }
 
 export interface ComposeFileRevision {

--- a/packages/cli/src/utils/result.ts
+++ b/packages/cli/src/utils/result.ts
@@ -1,6 +1,6 @@
 interface Result<T, E> {
-  isOk(): this is Ok<T, E>;
-  isErr(): this is Err<T, E>;
+  isOk: () => this is Ok<T, E>;
+  isErr: () => this is Err<T, E>;
 }
 
 export class Ok<T, E> implements Result<T, E> {


### PR DESCRIPTION
Standardize affected declarations as property signatures without changing their public contracts.

Closes #46

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>