### PR TITLE
chore(lint): enable import style

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -74,8 +74,7 @@ export default defineConfig({
     // Deferred: 3 errors
     "typescript/prefer-nullish-coalescing": "off",
     "typescript/method-signature-style": ["error", "property"],
-    // Deferred: 5 errors
-    "unicorn/import-style": "off",
+    "unicorn/import-style": "error",
     // Deferred: 2 errors
     "promise/prefer-await-to-callbacks": "off",
     // Deferred: 3 errors

--- a/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
@@ -13,7 +13,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import path from "node:path";
 
 import { expect, test } from "vitest";
 
@@ -32,8 +32,8 @@ test("discovers every supported Compose candidate without selecting one", async 
   const cwd = await createTempDirectory();
 
   try {
-    await writeFile(join(cwd, "compose.yaml"), "services: {}\n");
-    await writeFile(join(cwd, "docker-compose.yml"), "services: {}\n");
+    await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
+    await writeFile(path.join(cwd, "docker-compose.yml"), "services: {}\n");
 
     const result = await discoverComposeFiles(cwd);
 
@@ -69,8 +69,8 @@ test("recognizes only the supported Compose filenames", async () => {
   const cwd = await createTempDirectory();
 
   try {
-    await writeFile(join(cwd, "compose.json"), "{}\n");
-    await writeFile(join(cwd, "custom-compose.yaml"), "services: {}\n");
+    await writeFile(path.join(cwd, "compose.json"), "{}\n");
+    await writeFile(path.join(cwd, "custom-compose.yaml"), "services: {}\n");
 
     const result = await discoverComposeFiles(cwd);
 
@@ -95,7 +95,7 @@ test("does not treat a directory with a supported name as a Compose candidate", 
   const cwd = await createTempDirectory();
 
   try {
-    await mkdir(join(cwd, "compose.yaml"));
+    await mkdir(path.join(cwd, "compose.yaml"));
 
     const result = await discoverComposeFiles(cwd);
 
@@ -114,8 +114,11 @@ test("reports a recognized symlink during Compose discovery", async () => {
   const cwd = await createTempDirectory();
 
   try {
-    await writeFile(join(cwd, "user-compose.yaml"), "services: {}\n");
-    await symlink(join(cwd, "user-compose.yaml"), join(cwd, "compose.yaml"));
+    await writeFile(path.join(cwd, "user-compose.yaml"), "services: {}\n");
+    await symlink(
+      path.join(cwd, "user-compose.yaml"),
+      path.join(cwd, "compose.yaml")
+    );
 
     const result = await discoverComposeFiles(cwd);
 
@@ -173,7 +176,7 @@ volumes:
 `;
 
   try {
-    await writeFile(join(cwd, "compose.yaml"), source);
+    await writeFile(path.join(cwd, "compose.yaml"), source);
 
     const result = await readComposeDocument(cwd, "compose.yaml");
 
@@ -207,7 +210,7 @@ test("allows a Compose document to omit services for initialization", async () =
 
   try {
     await writeFile(
-      join(cwd, "compose.yaml"),
+      path.join(cwd, "compose.yaml"),
       "name: example\nnetworks:\n  internal:\n    driver: bridge\n"
     );
 
@@ -361,7 +364,7 @@ test("reports a non-missing read failure as structured data", async () => {
 
 test("replaces an existing Compose document through the write seam", async () => {
   const cwd = await createTempDirectory();
-  const composePath = join(cwd, "compose.yaml");
+  const composePath = path.join(cwd, "compose.yaml");
 
   try {
     await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
@@ -390,7 +393,7 @@ test("replaces an existing Compose document through the write seam", async () =>
 
 test("preserves an existing Compose file's permission mode bits", async () => {
   const cwd = await createTempDirectory();
-  const composePath = join(cwd, "compose.yaml");
+  const composePath = path.join(cwd, "compose.yaml");
 
   try {
     await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
@@ -418,8 +421,8 @@ test("preserves an existing Compose file's permission mode bits", async () => {
 
 test("uses normal filesystem defaults when creating a new Compose file", async () => {
   const cwd = await createTempDirectory();
-  const composePath = join(cwd, "compose.yaml");
-  const expectedPath = join(cwd, "expected-mode.txt");
+  const composePath = path.join(cwd, "compose.yaml");
+  const expectedPath = path.join(cwd, "expected-mode.txt");
 
   try {
     await writeFile(expectedPath, "");
@@ -438,8 +441,8 @@ test("uses normal filesystem defaults when creating a new Compose file", async (
 
 test("rejects a symlinked Compose path without replacing the link", async () => {
   const cwd = await createTempDirectory();
-  const targetPath = join(cwd, "user-compose.yaml");
-  const composePath = join(cwd, "compose.yaml");
+  const targetPath = path.join(cwd, "user-compose.yaml");
+  const composePath = path.join(cwd, "compose.yaml");
   const source = "services:\n  app:\n    image: user/app\n";
 
   try {
@@ -468,7 +471,7 @@ test("rejects a symlinked Compose path without replacing the link", async () => 
 
 test("rejects a stale revision without overwriting newer Compose content", async () => {
   const cwd = await createTempDirectory();
-  const composePath = join(cwd, "compose.yaml");
+  const composePath = path.join(cwd, "compose.yaml");
   const newerSource = "services:\n  app:\n    image: newer/app\n";
 
   try {
@@ -509,7 +512,7 @@ test("rejects a stale revision without overwriting newer Compose content", async
 
 test("reports serialization failures without touching an existing file", async () => {
   const cwd = await createTempDirectory();
-  const composePath = join(cwd, "compose.yaml");
+  const composePath = path.join(cwd, "compose.yaml");
   const source = "services:\n  app:\n    image: old/app\n";
 
   try {
@@ -549,7 +552,7 @@ test("reports serialization failures without touching an existing file", async (
 
 test("reports deterministic write failures without replacing the original", async () => {
   const cwd = await createTempDirectory();
-  const composePath = join(cwd, "compose.yaml");
+  const composePath = path.join(cwd, "compose.yaml");
   const source = "services:\n  app:\n    image: old/app\n";
 
   try {
@@ -589,7 +592,7 @@ test("reports deterministic write failures without replacing the original", asyn
 
 test("creates a new Compose file exclusively when another process wins the race", async () => {
   const cwd = await createTempDirectory();
-  const composePath = join(cwd, "compose.yaml");
+  const composePath = path.join(cwd, "compose.yaml");
   const competitorSource = "services:\n  competitor:\n    image: other/app\n";
 
   try {
@@ -625,7 +628,7 @@ test("creates a new Compose file exclusively when another process wins the race"
 
 test("reports replacement failures without leaving a temporary file", async () => {
   const cwd = await createTempDirectory();
-  const composePath = join(cwd, "compose.yaml");
+  const composePath = path.join(cwd, "compose.yaml");
   const source = "services:\n  app:\n    image: old/app\n";
 
   try {
@@ -663,7 +666,7 @@ async function readComposeFailure(source: string): Promise<{
   error: ComposeFileFailure | undefined;
 }> {
   const cwd = await createTempDirectory();
-  const composePath = join(cwd, "compose.yaml");
+  const composePath = path.join(cwd, "compose.yaml");
 
   try {
     await writeFile(composePath, source);
@@ -681,7 +684,7 @@ async function readComposeFailure(source: string): Promise<{
 }
 
 async function createTempDirectory(): Promise<string> {
-  return await mkdtemp(join(tmpdir(), "ayanokoji-compose-adapter-"));
+  return await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-adapter-"));
 }
 
 function createFileSystem(

--- a/packages/cli/src/commands/docker/helpers/compose-file-adapter.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-file-adapter.ts
@@ -8,7 +8,7 @@ import {
   unlink as unlinkOnDisk,
   writeFile as writeFileToDisk,
 } from "node:fs/promises";
-import { join } from "node:path";
+import path from "node:path";
 
 import { parseAllDocuments, stringify } from "yaml";
 
@@ -149,7 +149,7 @@ export async function discoverComposeFiles(
 
   for (const fileName of COMPOSE_FILE_NAMES) {
     try {
-      const stats = await fileSystem.stat(join(cwd, fileName));
+      const stats = await fileSystem.stat(path.join(cwd, fileName));
       if (isSymbolicLink(stats)) {
         return new Err({ fileName, kind: "symlinked-document" });
       }
@@ -177,11 +177,11 @@ export async function readComposeDocument(
   | Ok<ComposeDocumentSnapshot, ComposeFileFailure>
   | Err<ComposeDocumentSnapshot, ComposeFileFailure>
 > {
-  const path = join(cwd, fileName);
+  const documentPath = path.join(cwd, fileName);
   let initialStats: ComposeFileStats;
 
   try {
-    initialStats = await fileSystem.stat(path);
+    initialStats = await fileSystem.stat(documentPath);
   } catch (error) {
     if (isMissingFileError(error)) {
       return new Err({ fileName, kind: "missing-document" });
@@ -201,7 +201,7 @@ export async function readComposeDocument(
   let source: string;
 
   try {
-    source = await fileSystem.readFile(path);
+    source = await fileSystem.readFile(documentPath);
   } catch (error) {
     if (isMissingFileError(error)) {
       return new Err({ fileName, kind: "missing-document" });
@@ -212,7 +212,7 @@ export async function readComposeDocument(
 
   let finalStats: ComposeFileStats;
   try {
-    finalStats = await fileSystem.stat(path);
+    finalStats = await fileSystem.stat(documentPath);
   } catch {
     return new Err({ fileName, kind: "stale-document" });
   }
@@ -306,12 +306,12 @@ export async function writeComposeDocument(
   revision?: ComposeFileRevision,
   fileSystem: ComposeFileSystem = nodeFileSystem
 ): Promise<Ok<null, ComposeFileFailure> | Err<null, ComposeFileFailure>> {
-  const path = join(cwd, fileName);
+  const documentPath = path.join(cwd, fileName);
   const expectedRevision = revision;
   let targetStats: ComposeFileStats | undefined;
 
   try {
-    targetStats = await fileSystem.stat(path);
+    targetStats = await fileSystem.stat(documentPath);
   } catch (error) {
     if (!isMissingFileError(error)) {
       return new Err({ fileName, kind: "write-failure" });
@@ -328,7 +328,7 @@ export async function writeComposeDocument(
     }
 
     const revisionFailure = await verifyRevision(
-      path,
+      documentPath,
       fileName,
       expectedRevision,
       fileSystem,
@@ -348,7 +348,7 @@ export async function writeComposeDocument(
     return new Err({ fileName, kind: "serialization-failure" });
   }
 
-  const temporaryPath = join(cwd, `.${fileName}.${randomUUID()}.tmp`);
+  const temporaryPath = path.join(cwd, `.${fileName}.${randomUUID()}.tmp`);
   let temporaryFileExists = false;
 
   try {
@@ -367,7 +367,7 @@ export async function writeComposeDocument(
       }
 
       const revisionFailure = await verifyRevision(
-        path,
+        documentPath,
         fileName,
         expectedRevision,
         fileSystem
@@ -376,15 +376,15 @@ export async function writeComposeDocument(
         return new Err(revisionFailure);
       }
 
-      await fileSystem.rename(temporaryPath, path);
+      await fileSystem.rename(temporaryPath, documentPath);
       temporaryFileExists = false;
     } else {
       try {
-        await fileSystem.link(temporaryPath, path);
+        await fileSystem.link(temporaryPath, documentPath);
       } catch (error) {
         if (isExistingFileError(error)) {
           const failure = await getExistingTargetFailure(
-            path,
+            documentPath,
             fileName,
             fileSystem
           );

--- a/packages/cli/src/commands/docker/helpers/init-docker.test.ts
+++ b/packages/cli/src/commands/docker/helpers/init-docker.test.ts
@@ -1,6 +1,6 @@
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import path from "node:path";
 
 import { expect, test, vi } from "vitest";
 import { parse } from "yaml";
@@ -30,7 +30,7 @@ test("initDocker writes the transformed document after service selection", async
 
     expect(result.isOk()).toBeTruthy();
     const document = parse(
-      (await readFile(join(cwd, "compose.yaml"), "utf-8")).toString()
+      (await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toString()
     );
 
     expect(document.services.postgres.image).toBe("postgres:latest");
@@ -52,7 +52,7 @@ test("initDocker reports a service collision without writing a partial batch", a
     services:
       "  postgres:\n    image: user/postgres\n  app:\n    image: example/app",
   });
-  const original = await readFile(join(cwd, "compose.yaml"), "utf-8");
+  const original = await readFile(path.join(cwd, "compose.yaml"), "utf-8");
 
   try {
     const { initDocker } = await import("./init-docker");
@@ -64,17 +64,17 @@ test("initDocker reports a service collision without writing a partial batch", a
     }
 
     expect(result.error).toContain('service name "postgres"');
-    await expect(readFile(join(cwd, "compose.yaml"), "utf-8")).resolves.toBe(
-      original
-    );
+    await expect(
+      readFile(path.join(cwd, "compose.yaml"), "utf-8")
+    ).resolves.toBe(original);
   } finally {
     await rm(cwd, { force: true, recursive: true });
   }
 });
 
 test("initDocker returns a parse failure without writing the Compose file", async () => {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-compose-"));
-  const composePath = join(cwd, "compose.yaml");
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
+  const composePath = path.join(cwd, "compose.yaml");
   const invalidDocument = "services:\n  app: [";
   await writeFile(composePath, invalidDocument);
 
@@ -100,7 +100,7 @@ test("initDocker returns a parse failure without writing the Compose file", asyn
 
 test("initDocker prompts for a candidate when multiple Compose files exist", async () => {
   const cwd = await createComposeFixture();
-  const alternatePath = join(cwd, "docker-compose.yml");
+  const alternatePath = path.join(cwd, "docker-compose.yml");
   const alternateSource = `name: alternate
 services:
   app:
@@ -120,7 +120,7 @@ services:
       alternateSource
     );
     expect(
-      (await readFile(join(cwd, "compose.yaml"), "utf-8")).toString()
+      (await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toString()
     ).toBe(
       "name: example\nservices:\n  app:\n    image: example/app\n    labels:\n      com.example.owner: user\nvolumes:\n  shared_data:\n    labels:\n      com.example.owner: user\n"
     );
@@ -130,7 +130,7 @@ services:
 });
 
 test("initDocker prompts for a supported filename when no Compose file exists", async () => {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-compose-"));
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
 
   try {
     const { initDocker } = await import("./init-docker");
@@ -138,7 +138,7 @@ test("initDocker prompts for a supported filename when no Compose file exists", 
 
     expect(result.isOk()).toBeTruthy();
     expect(
-      (await readFile(join(cwd, "compose.yaml"), "utf-8")).toString()
+      (await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toString()
     ).toContain("services:");
   } finally {
     await rm(cwd, { force: true, recursive: true });
@@ -148,13 +148,13 @@ test("initDocker prompts for a supported filename when no Compose file exists", 
 async function createComposeFixture(
   overrides: { services?: string } = {}
 ): Promise<string> {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-compose-"));
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
   const services =
     overrides.services ??
     "  app:\n    image: example/app\n    labels:\n      com.example.owner: user";
 
   await writeFile(
-    join(cwd, "compose.yaml"),
+    path.join(cwd, "compose.yaml"),
     `name: example\nservices:\n${services}\nvolumes:\n  shared_data:\n    labels:\n      com.example.owner: user\n`
   );
 

--- a/packages/cli/src/commands/docker/init.test.ts
+++ b/packages/cli/src/commands/docker/init.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import path from "node:path";
 
 import { expect, test, vi } from "vitest";
 
@@ -33,9 +33,9 @@ vi.mock(import("~/utils/handle-error"), () => ({
 vi.mock(import("~/utils/prompts"), () => promptMocks);
 
 test("init reports an environment failure after the Compose file is written", async () => {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-docker-init-"));
-  const envPath = join(cwd, "env-directory");
-  await writeFile(join(cwd, "compose.yaml"), "services: {}\n");
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-docker-init-"));
+  const envPath = path.join(cwd, "env-directory");
+  await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
   await mkdir(envPath);
   confirmResults.splice(0, confirmResults.length, true, true);
 
@@ -56,7 +56,7 @@ test("init reports an environment failure after the Compose file is written", as
     );
 
     expect(
-      (await readFile(join(cwd, "compose.yaml"), "utf-8")).toString()
+      (await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toString()
     ).toContain("postgres:");
     expect(handleErrorMock).toHaveBeenCalledOnce();
   } finally {
@@ -66,7 +66,7 @@ test("init reports an environment failure after the Compose file is written", as
 
 test("init synchronizes the environment after a successful Compose write", async () => {
   const cwd = await createComposeFixture();
-  const envPath = join(cwd, ".env.local");
+  const envPath = path.join(cwd, ".env.local");
   confirmResults.splice(0, confirmResults.length, true, true);
 
   try {
@@ -83,9 +83,9 @@ test("init synchronizes the environment after a successful Compose write", async
     expect((await readFile(envPath, "utf-8")).toString()).toContain(
       "POSTGRESQL_URL=postgresql://docker:docker@localhost:5432/docker"
     );
-    expect((await readFile(join(cwd, ".gitignore"), "utf-8")).toString()).toBe(
-      ".env\n"
-    );
+    expect(
+      (await readFile(path.join(cwd, ".gitignore"), "utf-8")).toString()
+    ).toBe(".env\n");
   } finally {
     await rm(cwd, { force: true, recursive: true });
   }
@@ -93,7 +93,7 @@ test("init synchronizes the environment after a successful Compose write", async
 
 test("init succeeds without environment changes when synchronization is declined", async () => {
   const cwd = await createComposeFixture();
-  const envPath = join(cwd, ".env.local");
+  const envPath = path.join(cwd, ".env.local");
   confirmResults.splice(0, confirmResults.length, true, false);
 
   try {
@@ -108,14 +108,14 @@ test("init succeeds without environment changes when synchronization is declined
     ]);
 
     await expect(readFile(envPath)).rejects.toThrow();
-    await expect(readFile(join(cwd, ".gitignore"))).rejects.toThrow();
+    await expect(readFile(path.join(cwd, ".gitignore"))).rejects.toThrow();
   } finally {
     await rm(cwd, { force: true, recursive: true });
   }
 });
 
 async function createComposeFixture(): Promise<string> {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-docker-init-"));
-  await writeFile(join(cwd, "compose.yaml"), "services: {}\n");
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-docker-init-"));
+  await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
   return cwd;
 }

--- a/packages/cli/src/commands/docker/remove.test.ts
+++ b/packages/cli/src/commands/docker/remove.test.ts
@@ -7,7 +7,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import path from "node:path";
 
 import { expect, test, vi } from "vitest";
 import { parse } from "yaml";
@@ -45,8 +45,8 @@ vi.mock(import("~/utils/handle-error"), () => ({
 vi.mock(import("~/utils/prompts"), () => promptMocks);
 
 test("remove command writes the pure removal result", async () => {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-compose-remove-"));
-  const composePath = join(cwd, "compose.yaml");
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+  const composePath = path.join(cwd, "compose.yaml");
 
   await writeFile(
     composePath,
@@ -100,7 +100,7 @@ networks:
 });
 
 test("remove reports a missing Compose document without creating one", async () => {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-compose-remove-"));
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
 
   try {
     const { remove } = await import("./remove");
@@ -115,8 +115,8 @@ test("remove reports a missing Compose document without creating one", async () 
 });
 
 test("remove reports no services without writing a valid document", async () => {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-compose-remove-"));
-  const composePath = join(cwd, "compose.yaml");
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+  const composePath = path.join(cwd, "compose.yaml");
   const source = "name: example\nnetworks:\n  internal: {}\n";
   await writeFile(composePath, source);
 
@@ -133,9 +133,9 @@ test("remove reports no services without writing a valid document", async () => 
 });
 
 test("remove prompts for a candidate when multiple Compose files exist", async () => {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-compose-remove-"));
-  const firstPath = join(cwd, "compose.yaml");
-  const secondPath = join(cwd, "docker-compose.yml");
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+  const firstPath = path.join(cwd, "compose.yaml");
+  const secondPath = path.join(cwd, "docker-compose.yml");
   const source = `services:
   postgres:
     image: postgres:17
@@ -157,9 +157,9 @@ test("remove prompts for a candidate when multiple Compose files exist", async (
 });
 
 test("remove reports an environment failure after the Compose file is written", async () => {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-compose-remove-"));
-  const composePath = join(cwd, "compose.yaml");
-  const envPath = join(cwd, "env-directory");
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+  const composePath = path.join(cwd, "compose.yaml");
+  const envPath = path.join(cwd, "env-directory");
   await writeFile(
     composePath,
     `services:
@@ -194,9 +194,9 @@ test("remove reports an environment failure after the Compose file is written", 
 });
 
 test("remove synchronizes environment cleanup after a successful Compose write", async () => {
-  const cwd = await mkdtemp(join(tmpdir(), "ayanokoji-compose-remove-"));
-  const composePath = join(cwd, "compose.yaml");
-  const envPath = join(cwd, ".env");
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+  const composePath = path.join(cwd, "compose.yaml");
+  const envPath = path.join(cwd, ".env");
   await writeFile(
     composePath,
     `services:


### PR DESCRIPTION
Enable unicorn/import-style and standardize Node path imports without changing behavior.

Closes #47

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>