### PR TITLE
chore(lint): enable type conversion rule

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -54,8 +54,7 @@ export default defineConfig({
     "require-await": "off",
     // Deferred: 1 error
     "oxc/branches-sharing-code": "off",
-    // Deferred: 24 errors
-    "typescript/no-unnecessary-type-conversion": "off",
+    "typescript/no-unnecessary-type-conversion": "error",
     // Deferred: 12 errors
     "typescript/strict-boolean-expressions": "off",
     // Deferred: 7 errors

--- a/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
@@ -383,9 +383,7 @@ test("replaces an existing Compose document through the write seam", async () =>
     );
 
     expect(writeResult.isOk()).toBeTruthy();
-    expect((await readFile(composePath, "utf-8")).toString()).toContain(
-      "image: new/app"
-    );
+    expect(await readFile(composePath, "utf-8")).toContain("image: new/app");
   } finally {
     await removeTempDirectory(cwd);
   }
@@ -463,7 +461,7 @@ test("rejects a symlinked Compose path without replacing the link", async () => 
       kind: "symlinked-document",
     });
     expect((await lstat(composePath)).isSymbolicLink()).toBeTruthy();
-    expect((await readFile(targetPath, "utf-8")).toString()).toBe(source);
+    expect(await readFile(targetPath, "utf-8")).toBe(source);
   } finally {
     await removeTempDirectory(cwd);
   }
@@ -501,7 +499,7 @@ test("rejects a stale revision without overwriting newer Compose content", async
       fileName: "compose.yaml",
       kind: "stale-document",
     });
-    expect((await readFile(composePath, "utf-8")).toString()).toBe(newerSource);
+    expect(await readFile(composePath, "utf-8")).toBe(newerSource);
     expect(
       (await readdir(cwd)).filter((name) => name.startsWith(".compose.yaml."))
     ).toStrictEqual([]);
@@ -544,7 +542,7 @@ test("reports serialization failures without touching an existing file", async (
       fileName: "compose.yaml",
       kind: "serialization-failure",
     });
-    expect((await readFile(composePath, "utf-8")).toString()).toBe(source);
+    expect(await readFile(composePath, "utf-8")).toBe(source);
   } finally {
     await removeTempDirectory(cwd);
   }
@@ -584,7 +582,7 @@ test("reports deterministic write failures without replacing the original", asyn
       fileName: "compose.yaml",
       kind: "write-failure",
     });
-    expect((await readFile(composePath, "utf-8")).toString()).toBe(source);
+    expect(await readFile(composePath, "utf-8")).toBe(source);
   } finally {
     await removeTempDirectory(cwd);
   }
@@ -618,9 +616,7 @@ test("creates a new Compose file exclusively when another process wins the race"
       fileName: "compose.yaml",
       kind: "creation-conflict",
     });
-    expect((await readFile(composePath, "utf-8")).toString()).toBe(
-      competitorSource
-    );
+    expect(await readFile(composePath, "utf-8")).toBe(competitorSource);
   } finally {
     await removeTempDirectory(cwd);
   }
@@ -652,7 +648,7 @@ test("reports replacement failures without leaving a temporary file", async () =
     );
 
     expect(writeResult.isErr()).toBeTruthy();
-    expect((await readFile(composePath, "utf-8")).toString()).toBe(source);
+    expect(await readFile(composePath, "utf-8")).toBe(source);
     expect(
       (await readdir(cwd)).filter((name) => name.startsWith(".compose.yaml."))
     ).toStrictEqual([]);
@@ -675,7 +671,7 @@ async function readComposeFailure(source: string): Promise<{
     const error = result.isErr() ? result.error : undefined;
 
     return {
-      contents: (await readFile(composePath, "utf-8")).toString(),
+      contents: await readFile(composePath, "utf-8"),
       error,
     };
   } finally {
@@ -693,7 +689,7 @@ function createFileSystem(
   return {
     chmod,
     link,
-    readFile: async (path) => (await readFile(path, "utf-8")).toString(),
+    readFile: async (path) => await readFile(path, "utf-8"),
     rename,
     stat: lstat,
     unlink,

--- a/packages/cli/src/commands/docker/helpers/init-docker.test.ts
+++ b/packages/cli/src/commands/docker/helpers/init-docker.test.ts
@@ -30,7 +30,7 @@ test("initDocker writes the transformed document after service selection", async
 
     expect(result.isOk()).toBeTruthy();
     const document = parse(
-      (await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toString()
+      await readFile(path.join(cwd, "compose.yaml"), "utf-8")
     );
 
     expect(document.services.postgres.image).toBe("postgres:latest");
@@ -90,9 +90,7 @@ test("initDocker returns a parse failure without writing the Compose file", asyn
     expect(result.error).toBe(
       "Failed to parse existing Docker Compose file: compose.yaml"
     );
-    expect((await readFile(composePath, "utf-8")).toString()).toBe(
-      invalidDocument
-    );
+    expect(await readFile(composePath, "utf-8")).toBe(invalidDocument);
   } finally {
     await rm(cwd, { force: true, recursive: true });
   }
@@ -116,12 +114,8 @@ services:
     const result = await initDocker({ cwd });
 
     expect(result.isOk()).toBeTruthy();
-    expect((await readFile(alternatePath, "utf-8")).toString()).not.toBe(
-      alternateSource
-    );
-    expect(
-      (await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toString()
-    ).toBe(
+    expect(await readFile(alternatePath, "utf-8")).not.toBe(alternateSource);
+    expect(await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toBe(
       "name: example\nservices:\n  app:\n    image: example/app\n    labels:\n      com.example.owner: user\nvolumes:\n  shared_data:\n    labels:\n      com.example.owner: user\n"
     );
   } finally {
@@ -137,9 +131,9 @@ test("initDocker prompts for a supported filename when no Compose file exists", 
     const result = await initDocker({ cwd });
 
     expect(result.isOk()).toBeTruthy();
-    expect(
-      (await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toString()
-    ).toContain("services:");
+    expect(await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toContain(
+      "services:"
+    );
   } finally {
     await rm(cwd, { force: true, recursive: true });
   }

--- a/packages/cli/src/commands/docker/init.test.ts
+++ b/packages/cli/src/commands/docker/init.test.ts
@@ -55,9 +55,9 @@ test("init reports an environment failure after the Compose file is written", as
       "Docker Compose file was written successfully, but environment synchronization failed"
     );
 
-    expect(
-      (await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toString()
-    ).toContain("postgres:");
+    expect(await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toContain(
+      "postgres:"
+    );
     expect(handleErrorMock).toHaveBeenCalledOnce();
   } finally {
     await rm(cwd, { force: true, recursive: true });
@@ -80,12 +80,12 @@ test("init synchronizes the environment after a successful Compose write", async
       envPath,
     ]);
 
-    expect((await readFile(envPath, "utf-8")).toString()).toContain(
+    expect(await readFile(envPath, "utf-8")).toContain(
       "POSTGRESQL_URL=postgresql://docker:docker@localhost:5432/docker"
     );
-    expect(
-      (await readFile(path.join(cwd, ".gitignore"), "utf-8")).toString()
-    ).toBe(".env\n");
+    expect(await readFile(path.join(cwd, ".gitignore"), "utf-8")).toBe(
+      ".env\n"
+    );
   } finally {
     await rm(cwd, { force: true, recursive: true });
   }

--- a/packages/cli/src/commands/docker/remove.test.ts
+++ b/packages/cli/src/commands/docker/remove.test.ts
@@ -73,7 +73,7 @@ networks:
     const { remove } = await import("./remove");
     await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
 
-    const document = parse((await readFile(composePath, "utf-8")).toString());
+    const document = parse(await readFile(composePath, "utf-8"));
     expect(document).toStrictEqual({
       name: "example",
       networks: {
@@ -126,7 +126,7 @@ test("remove reports no services without writing a valid document", async () => 
     await expect(
       remove.parseAsync(["node", "ayanokoji", "--cwd", cwd])
     ).rejects.toThrow("No services found in the compose file.");
-    expect((await readFile(composePath, "utf-8")).toString()).toBe(source);
+    expect(await readFile(composePath, "utf-8")).toBe(source);
   } finally {
     await rm(cwd, { force: true, recursive: true });
   }
@@ -149,8 +149,8 @@ test("remove prompts for a candidate when multiple Compose files exist", async (
     const { remove } = await import("./remove");
     await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
 
-    expect((await readFile(secondPath, "utf-8")).toString()).not.toBe(source);
-    expect((await readFile(firstPath, "utf-8")).toString()).toBe(source);
+    expect(await readFile(secondPath, "utf-8")).not.toBe(source);
+    expect(await readFile(firstPath, "utf-8")).toBe(source);
   } finally {
     await rm(cwd, { force: true, recursive: true });
   }
@@ -185,9 +185,7 @@ test("remove reports an environment failure after the Compose file is written", 
       "Docker Compose file was written successfully, but environment synchronization failed"
     );
 
-    expect((await readFile(composePath, "utf-8")).toString()).not.toContain(
-      "postgres:"
-    );
+    expect(await readFile(composePath, "utf-8")).not.toContain("postgres:");
   } finally {
     await rm(cwd, { force: true, recursive: true });
   }
@@ -211,10 +209,8 @@ test("remove synchronizes environment cleanup after a successful Compose write",
     const { remove } = await import("./remove");
     await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
 
-    expect((await readFile(composePath, "utf-8")).toString()).not.toContain(
-      "postgres:"
-    );
-    expect((await readFile(envPath, "utf-8")).toString()).toBe("\n");
+    expect(await readFile(composePath, "utf-8")).not.toContain("postgres:");
+    expect(await readFile(envPath, "utf-8")).toBe("\n");
   } finally {
     confirmState.value = false;
     await rm(cwd, { force: true, recursive: true });


### PR DESCRIPTION
Remove redundant readFile string conversions from the affected tests and enforce the rule.

Closes #49

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>