### PR TITLE
chore(lint): enable require-unicode-regexp

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "dev": "next dev",
     "start": "next start",
+    "test": "node --experimental-strip-types --test src/**/*.test.ts",
     "postinstall": "fumadocs-mdx",
     "type-check": "next typegen && fumadocs-mdx && oxlint . --type-aware --type-check",
     "lint": "oxlint .",

--- a/apps/docs/src/lib/github.test.ts
+++ b/apps/docs/src/lib/github.test.ts
@@ -1,0 +1,18 @@
+import { deepStrictEqual } from "node:assert/strict";
+import { test } from "node:test";
+
+import { parseGitHubUrl } from "./github";
+
+void test("parses GitHub repository URLs with or without a trailing slash", () => {
+  deepStrictEqual(
+    parseGitHubUrl("https://github.com/fellipeutaka/ayanokoji/"),
+    {
+      owner: "fellipeutaka",
+      repo: "ayanokoji",
+    }
+  );
+  deepStrictEqual(parseGitHubUrl("https://github.com/octocat/Hello-World"), {
+    owner: "octocat",
+    repo: "Hello-World",
+  });
+});

--- a/apps/docs/src/lib/github.ts
+++ b/apps/docs/src/lib/github.ts
@@ -1,5 +1,5 @@
-const TRAILING_SLASH_REGEX = /\/$/;
-const GITHUB_URL_REGEX = /github\.com\/([^/]+)\/([^/]+)/;
+const TRAILING_SLASH_REGEX = /\/$/u;
+const GITHUB_URL_REGEX = /github\.com\/([^/]+)\/([^/]+)/u;
 
 export function parseGitHubUrl(url: string) {
   const cleanUrl = url.replace(TRAILING_SLASH_REGEX, "");

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -41,8 +41,7 @@ export default defineConfig({
     // Deferred: 3 errors
     "typescript/no-dynamic-delete": "off",
     "prefer-destructuring": "error",
-    // Deferred: 6 errors
-    "require-unicode-regexp": "off",
+    "require-unicode-regexp": "error",
     // Deferred: 9 errors
     "no-shadow": "off",
     // Deferred: 6 errors

--- a/packages/cli/src/commands/docker/helpers/compose-document.test.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-document.test.ts
@@ -210,7 +210,13 @@ test("does not create generated volumes for bind or anonymous mounts", () => {
     {
       config: {
         image: "example/app",
-        volumes: ["./data:/data", "/tmp/cache:/cache", "/anonymous"],
+        volumes: [
+          "./data:/data",
+          "/tmp/cache:/cache",
+          "C:/workspace:/workspace",
+          "C:\\workspace:/workspace",
+          "/anonymous",
+        ],
       },
       name: "app",
     },

--- a/packages/cli/src/commands/docker/helpers/compose-document.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-document.ts
@@ -1,6 +1,6 @@
 import { Err, Ok } from "~/utils/result";
 
-const WINDOWS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
+const WINDOWS_PATH_PATTERN = /^[A-Za-z]:[\\/]/u;
 
 export type ComposeServiceConfig = object;
 

--- a/packages/cli/src/utils/parse-env.test.ts
+++ b/packages/cli/src/utils/parse-env.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "vitest";
+
+import { parseEnv } from "./parse-env";
+
+test("parses quoted and colon-delimited values across Windows line endings", () => {
+  const env = [
+    "export API_KEY = secret",
+    'MESSAGE = "hello\\nworld"',
+    "LABEL: 'quoted value'",
+  ].join("\r\n");
+
+  expect(parseEnv(env)).toStrictEqual({
+    API_KEY: "secret",
+    LABEL: "quoted value",
+    MESSAGE: "hello\nworld",
+  });
+});

--- a/packages/cli/src/utils/parse-env.ts
+++ b/packages/cli/src/utils/parse-env.ts
@@ -1,12 +1,12 @@
 // Source: https://github.com/motdotla/dotenv/blob/master/lib/main.js
 
 const LINE =
-  /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/gm;
+  /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/gmu;
 
 export function parseEnv(env: string) {
   const obj: Record<string, string> = {};
 
-  const lines = env.replaceAll(/\r\n?/gm, "\n");
+  const lines = env.replaceAll(/\r\n?/gmu, "\n");
 
   let match = LINE.exec(lines);
 
@@ -19,7 +19,7 @@ export function parseEnv(env: string) {
 
     const [maybeQuote] = value;
 
-    value = value.replaceAll(/^(['"`])([\s\S]*)\1$/gm, "$2");
+    value = value.replaceAll(/^(['"`])([\s\S]*)\1$/gmu, "$2");
 
     if (maybeQuote === '"') {
       value = value.replaceAll("\\n", "\n");


### PR DESCRIPTION
Add Unicode-aware flags to the six existing regular expressions without changing their patterns or matching intent.

Closes #51

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>