### PR TITLE
chore(lint): enable prefer-named-capture-group

### DIFF
--- a/apps/docs/src/lib/github.ts
+++ b/apps/docs/src/lib/github.ts
@@ -1,16 +1,14 @@
 const TRAILING_SLASH_REGEX = /\/$/u;
-const GITHUB_URL_REGEX = /github\.com\/([^/]+)\/([^/]+)/u;
+const GITHUB_URL_REGEX = /github\.com\/(?<owner>[^/]+)\/(?<repo>[^/]+)/u;
 
 export function parseGitHubUrl(url: string) {
   const cleanUrl = url.replace(TRAILING_SLASH_REGEX, "");
   const match = GITHUB_URL_REGEX.exec(cleanUrl);
+  const { owner, repo } = match?.groups ?? {};
 
-  if (!match) {
+  if (!owner || !repo) {
     throw new Error("Invalid GitHub repository URL");
   }
 
-  return {
-    owner: match[1],
-    repo: match[2],
-  };
+  return { owner, repo };
 }

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -44,8 +44,7 @@ export default defineConfig({
     "require-unicode-regexp": "error",
     // Deferred: 9 errors
     "no-shadow": "off",
-    // Deferred: 6 errors
-    "prefer-named-capture-group": "off",
+    "prefer-named-capture-group": "error",
     // Deferred: 30 errors
     "unicorn/no-await-expression-member": "off",
     // Deferred: 20 errors

--- a/packages/cli/src/utils/parse-env.ts
+++ b/packages/cli/src/utils/parse-env.ts
@@ -1,7 +1,7 @@
 // Source: https://github.com/motdotla/dotenv/blob/master/lib/main.js
 
 const LINE =
-  /(?:^|^)\s*(?:export\s+)?([\w.-]+)(?:\s*=\s*?|:\s+?)(\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/gmu;
+  /(?:^|^)\s*(?:export\s+)?(?<key>[\w.-]+)(?:\s*=\s*?|:\s+?)(?<value>\s*'(?:\\'|[^'])*'|\s*"(?:\\"|[^"])*"|\s*`(?:\\`|[^`])*`|[^#\r\n]+)?\s*(?:#.*)?(?:$|$)/gmu;
 
 export function parseEnv(env: string) {
   const obj: Record<string, string> = {};
@@ -11,15 +11,18 @@ export function parseEnv(env: string) {
   let match = LINE.exec(lines);
 
   while (match) {
-    const [, key] = match;
+    const { key, value: matchedValue } = match.groups ?? {};
 
-    let value = match[2] || "";
+    let value = matchedValue || "";
 
     value = value.trim();
 
     const [maybeQuote] = value;
 
-    value = value.replaceAll(/^(['"`])([\s\S]*)\1$/gmu, "$2");
+    value = value.replaceAll(
+      /^(?<quote>['"`])(?<value>[\s\S]*)\k<quote>$/gmu,
+      "$<value>"
+    );
 
     if (maybeQuote === '"') {
       value = value.replaceAll("\\n", "\n");


### PR DESCRIPTION
Use named capture groups and named consumers without changing parser behavior.

Closes #52

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>