### PR TITLE
chore(lint): enable no-unsafe-assignment

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -60,8 +60,7 @@ export default defineConfig({
     "typescript/no-deprecated": "off",
     // Deferred: 13 errors
     "typescript/consistent-return": "off",
-    // Deferred: 2 errors
-    "typescript/no-unsafe-assignment": "off",
+    "typescript/no-unsafe-assignment": "error",
     // Deferred: 3 errors
     "typescript/no-unsafe-member-access": "off",
     // Deferred: 2 errors

--- a/packages/cli/src/commands/docker/helpers/init-docker.test.ts
+++ b/packages/cli/src/commands/docker/helpers/init-docker.test.ts
@@ -29,18 +29,38 @@ test("initDocker writes the transformed document after service selection", async
     const result = await initDocker({ cwd });
 
     expect(result.isOk()).toBeTruthy();
-    const document = parse(
+    const document: unknown = parse(
       await readFile(path.join(cwd, "compose.yaml"), "utf-8")
     );
 
-    expect(document.services.postgres.image).toBe("postgres:latest");
-    expect(document.services.app).toStrictEqual({
-      image: "example/app",
-      labels: { "com.example.owner": "user" },
-    });
-    expect(document.volumes).toStrictEqual({
-      postgres_data: {},
-      shared_data: { labels: { "com.example.owner": "user" } },
+    expect(document).toStrictEqual({
+      name: "example",
+      services: {
+        app: {
+          image: "example/app",
+          labels: { "com.example.owner": "user" },
+        },
+        postgres: {
+          environment: {
+            POSTGRES_DB: "docker",
+            POSTGRES_PASSWORD: "docker",
+            POSTGRES_USER: "docker",
+          },
+          healthcheck: {
+            interval: "10s",
+            retries: 5,
+            test: ["CMD-SHELL", "pg_isready -U docker -d docker"],
+            timeout: "5s",
+          },
+          image: "postgres:latest",
+          ports: ["5432:5432"],
+          volumes: ["postgres_data:/var/lib/postgresql/data"],
+        },
+      },
+      volumes: {
+        postgres_data: {},
+        shared_data: { labels: { "com.example.owner": "user" } },
+      },
     });
   } finally {
     await rm(cwd, { force: true, recursive: true });

--- a/packages/cli/src/commands/docker/remove.test.ts
+++ b/packages/cli/src/commands/docker/remove.test.ts
@@ -73,7 +73,7 @@ networks:
     const { remove } = await import("./remove");
     await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
 
-    const document = parse(await readFile(composePath, "utf-8"));
+    const document: unknown = parse(await readFile(composePath, "utf-8"));
     expect(document).toStrictEqual({
       name: "example",
       networks: {


### PR DESCRIPTION
Keep YAML parser results at an unknown boundary in Docker tests.

Closes #53

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>