### PR TITLE
chore(lint): enable no-unsafe-member-access

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -61,8 +61,7 @@ export default defineConfig({
     // Deferred: 13 errors
     "typescript/consistent-return": "off",
     "typescript/no-unsafe-assignment": "error",
-    // Deferred: 3 errors
-    "typescript/no-unsafe-member-access": "off",
+    "typescript/no-unsafe-member-access": "error",
     // Deferred: 2 errors
     "typescript/switch-exhaustiveness-check": "off",
     // Deferred: 3 errors


### PR DESCRIPTION
Enforce type-safe member access now that the deferred diagnostics are clear.

Closes #54

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>