### PR TITLE
chore(lint): enable consistent-return

### DIFF
--- a/apps/docs/src/lib/resolve-icon.test.ts
+++ b/apps/docs/src/lib/resolve-icon.test.ts
@@ -1,0 +1,20 @@
+import { strictEqual } from "node:assert/strict";
+import { test } from "node:test";
+
+import { resolveIcon } from "./resolve-icon";
+
+function Check() {
+  return null;
+}
+
+const icons = { Check };
+
+void test("returns undefined when an icon is missing or unknown", () => {
+  strictEqual(resolveIcon(undefined, icons), undefined);
+  strictEqual(resolveIcon("", icons), undefined);
+  strictEqual(resolveIcon("Missing", icons), undefined);
+});
+
+void test("creates an element for a known icon", () => {
+  strictEqual(resolveIcon("Check", icons)?.type, Check);
+});

--- a/apps/docs/src/lib/resolve-icon.ts
+++ b/apps/docs/src/lib/resolve-icon.ts
@@ -1,0 +1,11 @@
+import { createElement } from "react";
+import type { ComponentType, ReactElement } from "react";
+
+export function resolveIcon(
+  icon: string | undefined,
+  icons: Record<string, ComponentType>
+): ReactElement | undefined {
+  return icon !== undefined && icon !== "" && Object.hasOwn(icons, icon)
+    ? createElement(icons[icon])
+    : undefined;
+}

--- a/apps/docs/src/lib/source.ts
+++ b/apps/docs/src/lib/source.ts
@@ -1,25 +1,16 @@
 import { loader } from "fumadocs-core/source";
 import type { InferPageType } from "fumadocs-core/source";
 import { docs } from "fumadocs-mdx:collections/server";
-import { createElement } from "react";
 
 import { Icons } from "@/components/ui/icons";
 
-function isIconName(icon: string): icon is keyof typeof Icons {
-  return Object.hasOwn(Icons, icon);
-}
+import { resolveIcon } from "./resolve-icon";
 
 // See https://fumadocs.dev/docs/headless/source-api for more info
 export const source = loader({
   baseUrl: "/docs",
   icon(icon) {
-    if (icon === undefined || icon === "") {
-      return;
-    }
-
-    if (isIconName(icon)) {
-      return createElement(Icons[icon]);
-    }
+    return resolveIcon(icon, Icons);
   },
   source: docs.toFumadocsSource(),
 });

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -55,8 +55,7 @@ export default defineConfig({
     "typescript/strict-boolean-expressions": "error",
     "typescript/no-unsafe-type-assertion": "error",
     "typescript/no-deprecated": "error",
-    // Deferred: 13 errors
-    "typescript/consistent-return": "off",
+    "typescript/consistent-return": "error",
     "typescript/no-unsafe-assignment": "error",
     "typescript/no-unsafe-member-access": "error",
     "typescript/switch-exhaustiveness-check": "error",

--- a/packages/cli/src/commands/docker/databases/mailpit.ts
+++ b/packages/cli/src/commands/docker/databases/mailpit.ts
@@ -1,8 +1,7 @@
-import { formatZodErrors } from "~/utils/format-zod-errors";
 import { enhancedConfirm, enhancedSelect, enhancedText } from "~/utils/prompts";
 
 import type { CreateComposeServiceResult, DatabaseImageConfig } from ".";
-import { getPortSchema } from "../schemas/port";
+import { validatePort } from "../schemas/port";
 
 const imageConfig: DatabaseImageConfig = {
   defaultPort: 8025,
@@ -36,11 +35,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: "1025",
     message: "What is the SMTP port?",
     validate(value) {
-      const result = getPortSchema(1025).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, 1025);
     },
   });
 
@@ -48,11 +43,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: String(imageConfig.defaultPort),
     message: "What is the Web UI port?",
     validate(value) {
-      const result = getPortSchema(imageConfig.defaultPort).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, imageConfig.defaultPort);
     },
   });
 

--- a/packages/cli/src/commands/docker/databases/mariadb.ts
+++ b/packages/cli/src/commands/docker/databases/mariadb.ts
@@ -1,8 +1,7 @@
-import { formatZodErrors } from "~/utils/format-zod-errors";
 import { enhancedConfirm, enhancedSelect, enhancedText } from "~/utils/prompts";
 
 import type { CreateComposeServiceResult, DatabaseImageConfig } from ".";
-import { getPortSchema } from "../schemas/port";
+import { validatePort } from "../schemas/port";
 
 const imageConfig: DatabaseImageConfig = {
   defaultPort: 3306,
@@ -40,11 +39,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: String(imageConfig.defaultPort),
     message: "What is the MariaDB port?",
     validate(value) {
-      const result = getPortSchema(imageConfig.defaultPort).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, imageConfig.defaultPort);
     },
   });
 

--- a/packages/cli/src/commands/docker/databases/minio.ts
+++ b/packages/cli/src/commands/docker/databases/minio.ts
@@ -1,8 +1,7 @@
-import { formatZodErrors } from "~/utils/format-zod-errors";
 import { enhancedConfirm, enhancedSelect, enhancedText } from "~/utils/prompts";
 
 import type { CreateComposeServiceResult, DatabaseImageConfig } from ".";
-import { getPortSchema } from "../schemas/port";
+import { validatePort } from "../schemas/port";
 
 const imageConfig: DatabaseImageConfig = {
   defaultPort: 9000,
@@ -45,11 +44,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: String(imageConfig.defaultPort),
     message: "What is the API port?",
     validate(value) {
-      const result = getPortSchema(imageConfig.defaultPort).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, imageConfig.defaultPort);
     },
   });
 
@@ -57,11 +52,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: "9001",
     message: "What is the Console port?",
     validate(value) {
-      const result = getPortSchema(9001).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, 9001);
     },
   });
 

--- a/packages/cli/src/commands/docker/databases/mongodb.ts
+++ b/packages/cli/src/commands/docker/databases/mongodb.ts
@@ -1,8 +1,7 @@
-import { formatZodErrors } from "~/utils/format-zod-errors";
 import { enhancedConfirm, enhancedSelect, enhancedText } from "~/utils/prompts";
 
 import type { CreateComposeServiceResult, DatabaseImageConfig } from ".";
-import { getPortSchema } from "../schemas/port";
+import { validatePort } from "../schemas/port";
 
 const imageConfig: DatabaseImageConfig = {
   defaultPort: 27_017,
@@ -40,11 +39,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: String(imageConfig.defaultPort),
     message: "What is the MongoDB port?",
     validate(value) {
-      const result = getPortSchema(imageConfig.defaultPort).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, imageConfig.defaultPort);
     },
   });
 

--- a/packages/cli/src/commands/docker/databases/mysql.ts
+++ b/packages/cli/src/commands/docker/databases/mysql.ts
@@ -1,8 +1,7 @@
-import { formatZodErrors } from "~/utils/format-zod-errors";
 import { enhancedConfirm, enhancedSelect, enhancedText } from "~/utils/prompts";
 
 import type { CreateComposeServiceResult, DatabaseImageConfig } from ".";
-import { getPortSchema } from "../schemas/port";
+import { validatePort } from "../schemas/port";
 
 const imageConfig: DatabaseImageConfig = {
   defaultPort: 3306,
@@ -40,11 +39,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: String(imageConfig.defaultPort),
     message: "What is the MySQL port?",
     validate(value) {
-      const result = getPortSchema(imageConfig.defaultPort).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, imageConfig.defaultPort);
     },
   });
 

--- a/packages/cli/src/commands/docker/databases/postgresql.ts
+++ b/packages/cli/src/commands/docker/databases/postgresql.ts
@@ -1,8 +1,7 @@
-import { formatZodErrors } from "~/utils/format-zod-errors";
 import { enhancedConfirm, enhancedSelect, enhancedText } from "~/utils/prompts";
 
 import type { CreateComposeServiceResult, DatabaseImageConfig } from ".";
-import { getPortSchema } from "../schemas/port";
+import { validatePort } from "../schemas/port";
 
 const imageConfig: DatabaseImageConfig = {
   defaultPort: 5432,
@@ -45,11 +44,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: String(imageConfig.defaultPort),
     message: "What is the Postgres port?",
     validate(value) {
-      const result = getPortSchema(imageConfig.defaultPort).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, imageConfig.defaultPort);
     },
   });
 

--- a/packages/cli/src/commands/docker/databases/rabbitmq.ts
+++ b/packages/cli/src/commands/docker/databases/rabbitmq.ts
@@ -1,8 +1,7 @@
-import { formatZodErrors } from "~/utils/format-zod-errors";
 import { enhancedConfirm, enhancedSelect, enhancedText } from "~/utils/prompts";
 
 import type { CreateComposeServiceResult, DatabaseImageConfig } from ".";
-import { getPortSchema } from "../schemas/port";
+import { validatePort } from "../schemas/port";
 
 const imageConfig: DatabaseImageConfig = {
   defaultPort: 5672,
@@ -44,11 +43,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: String(imageConfig.defaultPort),
     message: "What is the AMQP port?",
     validate(value) {
-      const result = getPortSchema(imageConfig.defaultPort).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, imageConfig.defaultPort);
     },
   });
 
@@ -56,11 +51,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: "15672",
     message: "What is the Management UI port?",
     validate(value) {
-      const result = getPortSchema(15_672).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, 15_672);
     },
   });
 

--- a/packages/cli/src/commands/docker/databases/redis.ts
+++ b/packages/cli/src/commands/docker/databases/redis.ts
@@ -1,8 +1,7 @@
-import { formatZodErrors } from "~/utils/format-zod-errors";
 import { enhancedConfirm, enhancedSelect, enhancedText } from "~/utils/prompts";
 
 import type { CreateComposeServiceResult, DatabaseImageConfig } from ".";
-import { getPortSchema } from "../schemas/port";
+import { validatePort } from "../schemas/port";
 
 const imageConfig: DatabaseImageConfig = {
   defaultPort: 6379,
@@ -35,11 +34,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: String(imageConfig.defaultPort),
     message: "What is the Redis port?",
     validate(value) {
-      const result = getPortSchema(imageConfig.defaultPort).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, imageConfig.defaultPort);
     },
   });
 

--- a/packages/cli/src/commands/docker/databases/valkey.ts
+++ b/packages/cli/src/commands/docker/databases/valkey.ts
@@ -1,8 +1,7 @@
-import { formatZodErrors } from "~/utils/format-zod-errors";
 import { enhancedConfirm, enhancedSelect, enhancedText } from "~/utils/prompts";
 
 import type { CreateComposeServiceResult, DatabaseImageConfig } from ".";
-import { getPortSchema } from "../schemas/port";
+import { validatePort } from "../schemas/port";
 
 const imageConfig: DatabaseImageConfig = {
   defaultPort: 6379,
@@ -36,11 +35,7 @@ async function createComposeService(): Promise<CreateComposeServiceResult> {
     defaultValue: String(imageConfig.defaultPort),
     message: "What is the Valkey port?",
     validate(value) {
-      const result = getPortSchema(imageConfig.defaultPort).safeParse(value);
-
-      if (!result.success) {
-        return formatZodErrors(result.error);
-      }
+      return validatePort(value, imageConfig.defaultPort);
     },
   });
 

--- a/packages/cli/src/commands/docker/schemas/port.test.ts
+++ b/packages/cli/src/commands/docker/schemas/port.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "vitest";
+
+import { validatePort } from "./port";
+
+test("returns undefined for a valid port", () => {
+  expect(validatePort("5432", 5432)).toBeUndefined();
+});
+
+test("returns a validation message for an invalid port", () => {
+  expect(validatePort("0", 5432)).toContain("Port must be greater than 0");
+});

--- a/packages/cli/src/commands/docker/schemas/port.ts
+++ b/packages/cli/src/commands/docker/schemas/port.ts
@@ -1,5 +1,7 @@
 import * as z from "zod/mini";
 
+import { formatZodErrors } from "~/utils/format-zod-errors";
+
 const stringToNumber = z.pipe(z.string(), z.transform(Number));
 
 export const getPortSchema = (defaultPort: number) =>
@@ -17,3 +19,12 @@ export const getPortSchema = (defaultPort: number) =>
     ),
     defaultPort
   );
+
+export function validatePort(
+  value: string | undefined,
+  defaultPort: number
+): string | undefined {
+  const result = getPortSchema(defaultPort).safeParse(value);
+
+  return result.success ? undefined : formatZodErrors(result.error);
+}


### PR DESCRIPTION
Make validation and icon callbacks return explicit outcomes.

Closes #60

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>