### PR TITLE
chore(lint): enable prefer-await-to-callbacks

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -60,8 +60,7 @@ export default defineConfig({
     "typescript/prefer-nullish-coalescing": "error",
     "typescript/method-signature-style": ["error", "property"],
     "unicorn/import-style": "error",
-    // Deferred: 2 errors
-    "promise/prefer-await-to-callbacks": "off",
+    "promise/prefer-await-to-callbacks": "error",
     // Deferred: 3 errors
     "unicorn/no-array-reduce": "off",
     "unicorn/no-object-as-default-parameter": "error",

--- a/packages/cli/src/commands/docker/init.test.ts
+++ b/packages/cli/src/commands/docker/init.test.ts
@@ -6,6 +6,9 @@ import { expect, test, vi } from "vitest";
 
 const { confirmResults, handleErrorMock, promptMocks } = vi.hoisted(() => {
   const confirmResults = [true, true];
+  // Keep the synchronous handleError contract so mocked command failures stop
+  // execution just like the process-exiting production implementation.
+  // oxlint-disable-next-line promise/prefer-await-to-callbacks
   const handleErrorMock = vi.fn((error: string): never => {
     throw new Error(error);
   });

--- a/packages/cli/src/commands/docker/remove.test.ts
+++ b/packages/cli/src/commands/docker/remove.test.ts
@@ -15,6 +15,9 @@ import { parse } from "yaml";
 const { confirmState, enhancedSelectMock, handleErrorMock, promptMocks } =
   vi.hoisted(() => {
     const confirmState = { value: false };
+    // Keep the synchronous handleError contract so mocked command failures stop
+    // execution just like the process-exiting production implementation.
+    // oxlint-disable-next-line promise/prefer-await-to-callbacks
     const handleErrorMock = vi.fn((error: string): never => {
       throw new Error(error);
     });


### PR DESCRIPTION
Closes #63

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>