### PR TITLE
chore(lint): enable no-dynamic-delete

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -37,8 +37,7 @@ export default defineConfig({
     "no-await-in-loop": "error",
     // Deferred: 118 errors
     "no-use-before-define": "off",
-    // Deferred: 3 errors
-    "typescript/no-dynamic-delete": "off",
+    "typescript/no-dynamic-delete": "error",
     "prefer-destructuring": "error",
     "require-unicode-regexp": "error",
     // Deferred: 9 errors

--- a/packages/cli/src/commands/docker/helpers/compose-document.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-document.ts
@@ -243,9 +243,6 @@ export function removeServices(
     }
   }
 
-  const nextServices: Record<string, ComposeServiceConfig> = {
-    ...services,
-  };
   const removedGeneratedVolumes = new Set<string>();
 
   for (const serviceName of serviceNames) {
@@ -260,28 +257,36 @@ export function removeServices(
     })) {
       removedGeneratedVolumes.add(volumeName);
     }
-    delete nextServices[serviceName];
   }
+
+  const nextServices = Object.fromEntries(
+    Object.entries(services).filter(
+      ([serviceName]) => !requestedNames.has(serviceName)
+    )
+  );
 
   let nextVolumes: Record<string, unknown> | undefined;
   let volumeChanged = false;
   if (existingVolumes !== undefined) {
-    nextVolumes = { ...existingVolumes };
     const remainingVolumeNames = new Set(
       Object.values(nextServices).flatMap((service) =>
         getReferencedVolumeNames(service)
       )
     );
 
-    for (const volumeName of removedGeneratedVolumes) {
-      if (
-        !remainingVolumeNames.has(volumeName) &&
-        isGeneratedVolumeDeclaration(nextVolumes[volumeName])
-      ) {
-        delete nextVolumes[volumeName];
-        volumeChanged = true;
-      }
-    }
+    nextVolumes = Object.fromEntries(
+      Object.entries(existingVolumes).filter(([volumeName, declaration]) => {
+        const shouldRemove =
+          removedGeneratedVolumes.has(volumeName) &&
+          !remainingVolumeNames.has(volumeName) &&
+          isGeneratedVolumeDeclaration(declaration);
+        if (shouldRemove) {
+          volumeChanged = true;
+        }
+
+        return !shouldRemove;
+      })
+    );
   }
 
   const nextDocument: ComposeDocument = {

--- a/packages/cli/src/commands/docker/remove.ts
+++ b/packages/cli/src/commands/docker/remove.ts
@@ -167,10 +167,12 @@ export const remove = new Command()
         });
 
         if (removeEnvVars) {
-          const newEnvVars = { ...existingEnvVars };
-          for (const key of envVarsToRemove) {
-            delete newEnvVars[key];
-          }
+          const envVarsToRemoveSet = new Set(envVarsToRemove);
+          const newEnvVars = Object.fromEntries(
+            Object.entries(existingEnvVars).filter(
+              ([key]) => !envVarsToRemoveSet.has(key)
+            )
+          );
 
           const writeResult = await writeEnvFile(envPath, newEnvVars);
           if (writeResult.isErr()) {


### PR DESCRIPTION
Replace dynamic object deletion with filtered state updates while preserving Compose and environment object shapes.

Closes #65

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>