### PR TITLE
chore(lint): enable parameter-properties

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -59,8 +59,7 @@ export default defineConfig({
     "unicorn/no-array-reduce": "error",
     "unicorn/no-object-as-default-parameter": "error",
     "max-classes-per-file": "error",
-    // Deferred: 2 errors
-    "typescript/parameter-properties": "off",
+    "typescript/parameter-properties": "error",
     // Deferred: 4 errors
     "class-methods-use-this": "off",
   },

--- a/packages/cli/src/utils/err.ts
+++ b/packages/cli/src/utils/err.ts
@@ -2,7 +2,11 @@ import type { Ok } from "./ok";
 import type { Result } from "./result-contract";
 
 export class Err<T, E> implements Result<T, E> {
-  constructor(readonly error: E) {}
+  readonly error: E;
+
+  constructor(error: E) {
+    this.error = error;
+  }
 
   isOk(): this is Ok<T, E> {
     return false;

--- a/packages/cli/src/utils/ok.ts
+++ b/packages/cli/src/utils/ok.ts
@@ -2,7 +2,11 @@ import type { Err } from "./err";
 import type { Result } from "./result-contract";
 
 export class Ok<T, E> implements Result<T, E> {
-  constructor(readonly value: T) {}
+  readonly value: T;
+
+  constructor(value: T) {
+    this.value = value;
+  }
 
   isOk(): this is Ok<T, E> {
     return true;

--- a/packages/cli/src/utils/result.test.ts
+++ b/packages/cli/src/utils/result.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+
+import { Err, Ok } from "./result";
+
+test("Ok stores its value and identifies a successful result", () => {
+  const result = new Ok<number, string>(42);
+
+  expect(result.value).toBe(42);
+  expect(result.isOk()).toBe(true);
+  expect(result.isErr()).toBe(false);
+});
+
+test("Err stores its error and identifies a failed result", () => {
+  const result = new Err<number, string>("failure");
+
+  expect(result.error).toBe("failure");
+  expect(result.isOk()).toBe(false);
+  expect(result.isErr()).toBe(true);
+});


### PR DESCRIPTION
Initialize result fields explicitly in constructors while preserving the existing Ok and Err contracts. Add focused tests for their stored values and type guards.

Closes #71

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>