### PR TITLE
chore(lint): migrate Docker use-before-define

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -19,6 +19,15 @@ export default defineConfig({
     "**/.opencode/**",
     "**/.turbo/**",
   ],
+  overrides: [
+    {
+      // Keep the migration scoped while the remaining CLI baseline is deferred.
+      files: ["packages/cli/src/commands/docker/**/*.ts"],
+      rules: {
+        "no-use-before-define": "error",
+      },
+    },
+  ],
 
   rules: {
     "sort-keys": "off",
@@ -34,7 +43,6 @@ export default defineConfig({
     complexity: "error",
     "no-warning-comments": "error",
     "no-await-in-loop": "error",
-    // Deferred: 118 errors
     "no-use-before-define": "off",
     "typescript/no-dynamic-delete": "error",
     "prefer-destructuring": "error",

--- a/packages/cli/src/commands/docker/helpers/compose-document.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-document.ts
@@ -62,6 +62,291 @@ interface RemovedVolumeResult {
   volumeChanged: boolean;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(
+  value: Record<string, unknown> | undefined,
+  key: string
+): boolean {
+  return value !== undefined && Object.hasOwn(value, key);
+}
+
+function getMountSource(mount: unknown): string | undefined {
+  if (typeof mount === "string") {
+    const separatorIndex = mount.indexOf(":");
+    if (separatorIndex <= 0) {
+      return undefined;
+    }
+
+    const source = mount.slice(0, separatorIndex);
+    if (
+      source.startsWith("/") ||
+      source.startsWith("./") ||
+      source.startsWith("../") ||
+      source.startsWith("~") ||
+      WINDOWS_PATH_PATTERN.test(mount)
+    ) {
+      return undefined;
+    }
+
+    return source;
+  }
+
+  if (!isRecord(mount) || typeof mount.source !== "string") {
+    return undefined;
+  }
+
+  if (mount.type !== undefined && mount.type !== "volume") {
+    return undefined;
+  }
+
+  return mount.source;
+}
+
+function getDependencyNames(service: ComposeServiceConfig): string[] {
+  if (!isRecord(service) || service.depends_on === undefined) {
+    return [];
+  }
+
+  if (Array.isArray(service.depends_on)) {
+    return service.depends_on.filter(
+      (dependency): dependency is string => typeof dependency === "string"
+    );
+  }
+
+  if (isRecord(service.depends_on)) {
+    return Object.keys(service.depends_on);
+  }
+
+  return [];
+}
+
+function isGeneratedVolumeDeclaration(value: unknown): boolean {
+  return isRecord(value) && Object.keys(value).length === 0;
+}
+
+function withoutVolumes(document: ComposeDocument): ComposeDocument {
+  const { volumes: _volumes, ...documentWithoutVolumes } = document;
+  return documentWithoutVolumes;
+}
+
+function getGeneratedVolumeNames(entry: ComposeServiceEntry): string[] {
+  const config = isRecord(entry.config) ? entry.config : undefined;
+  const volumes = config?.volumes;
+  if (!Array.isArray(volumes)) {
+    return [];
+  }
+
+  const generatedVolumeName = `${entry.name}_data`;
+
+  return volumes.flatMap((mount) => {
+    const source = getMountSource(mount);
+    return source === generatedVolumeName ? [source] : [];
+  });
+}
+
+function getReferencedVolumeNames(service: ComposeServiceConfig): string[] {
+  if (!(isRecord(service) && Array.isArray(service.volumes))) {
+    return [];
+  }
+
+  return service.volumes.flatMap((mount) => {
+    const source = getMountSource(mount);
+    return source !== undefined && source !== "" ? [source] : [];
+  });
+}
+
+function validateRequestedServiceNames(
+  services: Record<string, ComposeServiceConfig>,
+  serviceNames: readonly string[]
+): ComposeMutationResult<Set<string>> {
+  const requestedNames = new Set<string>();
+
+  for (const [index, serviceName] of serviceNames.entries()) {
+    if (typeof serviceName !== "string" || serviceName.length === 0) {
+      return new Err({
+        index,
+        kind: "invalid-service-entry",
+        reason: "empty-name",
+        ...(typeof serviceName === "string" && { serviceName }),
+      });
+    }
+
+    if (requestedNames.has(serviceName)) {
+      return new Err({
+        kind: "service-name-conflict",
+        scope: "requested-batch",
+        serviceName,
+      });
+    }
+
+    if (!hasOwn(services, serviceName)) {
+      return new Err({ kind: "service-not-found", serviceName });
+    }
+
+    requestedNames.add(serviceName);
+  }
+
+  return new Ok(requestedNames);
+}
+
+function findServiceDependencyConflict(
+  services: Record<string, ComposeServiceConfig>,
+  requestedNames: Set<string>
+): ComposeMutationFailure | undefined {
+  for (const [serviceName, service] of Object.entries(services)) {
+    if (requestedNames.has(serviceName)) {
+      continue;
+    }
+
+    const dependencyName = getDependencyNames(service).find((name) =>
+      requestedNames.has(name)
+    );
+    if (dependencyName !== undefined) {
+      return {
+        dependencyName,
+        kind: "service-dependency-conflict",
+        serviceName,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function validateServiceRemoval(
+  document: ComposeDocument,
+  serviceNames: readonly string[]
+): ComposeMutationResult<ServiceRemovalContext> {
+  if (!isRecord(document)) {
+    return new Err({ field: "document", kind: "invalid-document" });
+  }
+
+  if (serviceNames.length === 0) {
+    return new Err({ kind: "empty-service-batch" });
+  }
+
+  const existingServices = document.services;
+  if (existingServices !== undefined && !isRecord(existingServices)) {
+    return new Err({ field: "services", kind: "invalid-document" });
+  }
+
+  const existingVolumes = document.volumes;
+  if (existingVolumes !== undefined && !isRecord(existingVolumes)) {
+    return new Err({ field: "volumes", kind: "invalid-document" });
+  }
+
+  const services = existingServices ?? {};
+  const requestedNamesResult = validateRequestedServiceNames(
+    services,
+    serviceNames
+  );
+  if (requestedNamesResult.isErr()) {
+    return new Err(requestedNamesResult.error);
+  }
+
+  const dependencyFailure = findServiceDependencyConflict(
+    services,
+    requestedNamesResult.value
+  );
+  if (dependencyFailure !== undefined) {
+    return new Err(dependencyFailure);
+  }
+
+  return new Ok({
+    existingVolumes,
+    requestedNames: requestedNamesResult.value,
+    services,
+  });
+}
+
+function collectRemovedGeneratedVolumeNames(
+  services: Record<string, ComposeServiceConfig>,
+  serviceNames: readonly string[]
+): ComposeMutationResult<Set<string>> {
+  const removedGeneratedVolumes = new Set<string>();
+  for (const serviceName of serviceNames) {
+    const service = services[serviceName];
+    if (!isRecord(service)) {
+      return new Err({ field: "services", kind: "invalid-document" });
+    }
+
+    for (const volumeName of getGeneratedVolumeNames({
+      config: service,
+      name: serviceName,
+    })) {
+      removedGeneratedVolumes.add(volumeName);
+    }
+  }
+
+  return new Ok(removedGeneratedVolumes);
+}
+
+function withoutRequestedServices(
+  services: Record<string, ComposeServiceConfig>,
+  requestedNames: Set<string>
+): Record<string, ComposeServiceConfig> {
+  return Object.fromEntries(
+    Object.entries(services).filter(
+      ([serviceName]) => !requestedNames.has(serviceName)
+    )
+  );
+}
+
+function removeUnusedGeneratedVolumes(
+  existingVolumes: Record<string, unknown> | undefined,
+  nextServices: Record<string, ComposeServiceConfig>,
+  removedGeneratedVolumes: Set<string>
+): RemovedVolumeResult {
+  if (existingVolumes === undefined) {
+    return { volumeChanged: false };
+  }
+
+  const remainingVolumeNames = new Set(
+    Object.values(nextServices).flatMap((service) =>
+      getReferencedVolumeNames(service)
+    )
+  );
+  let volumeChanged = false;
+  const nextVolumes = Object.fromEntries(
+    Object.entries(existingVolumes).filter(([volumeName, declaration]) => {
+      const shouldRemove =
+        removedGeneratedVolumes.has(volumeName) &&
+        !remainingVolumeNames.has(volumeName) &&
+        isGeneratedVolumeDeclaration(declaration);
+      if (shouldRemove) {
+        volumeChanged = true;
+      }
+
+      return !shouldRemove;
+    })
+  );
+
+  return { nextVolumes, volumeChanged };
+}
+
+function createRemovedDocument(
+  document: ComposeDocument,
+  nextServices: Record<string, ComposeServiceConfig>,
+  volumeResult: RemovedVolumeResult
+): ComposeDocument {
+  const { nextVolumes, volumeChanged } = volumeResult;
+  const hasRemainingVolumes =
+    nextVolumes !== undefined && Object.keys(nextVolumes).length > 0;
+  const baseDocument =
+    volumeChanged && !hasRemainingVolumes ? withoutVolumes(document) : document;
+
+  return {
+    ...baseDocument,
+    services: nextServices,
+    ...(nextVolumes !== undefined && (!volumeChanged || hasRemainingVolumes)
+      ? { volumes: nextVolumes }
+      : {}),
+  };
+}
+
 export function getServiceNames(document: unknown): string[] {
   if (!(isRecord(document) && isRecord(document.services))) {
     return [];
@@ -215,289 +500,4 @@ export function removeServices(
   );
 
   return new Ok(createRemovedDocument(document, nextServices, volumeResult));
-}
-
-function validateServiceRemoval(
-  document: ComposeDocument,
-  serviceNames: readonly string[]
-): ComposeMutationResult<ServiceRemovalContext> {
-  if (!isRecord(document)) {
-    return new Err({ field: "document", kind: "invalid-document" });
-  }
-
-  if (serviceNames.length === 0) {
-    return new Err({ kind: "empty-service-batch" });
-  }
-
-  const existingServices = document.services;
-  if (existingServices !== undefined && !isRecord(existingServices)) {
-    return new Err({ field: "services", kind: "invalid-document" });
-  }
-
-  const existingVolumes = document.volumes;
-  if (existingVolumes !== undefined && !isRecord(existingVolumes)) {
-    return new Err({ field: "volumes", kind: "invalid-document" });
-  }
-
-  const services = existingServices ?? {};
-  const requestedNamesResult = validateRequestedServiceNames(
-    services,
-    serviceNames
-  );
-  if (requestedNamesResult.isErr()) {
-    return new Err(requestedNamesResult.error);
-  }
-
-  const dependencyFailure = findServiceDependencyConflict(
-    services,
-    requestedNamesResult.value
-  );
-  if (dependencyFailure !== undefined) {
-    return new Err(dependencyFailure);
-  }
-
-  return new Ok({
-    existingVolumes,
-    requestedNames: requestedNamesResult.value,
-    services,
-  });
-}
-
-function validateRequestedServiceNames(
-  services: Record<string, ComposeServiceConfig>,
-  serviceNames: readonly string[]
-): ComposeMutationResult<Set<string>> {
-  const requestedNames = new Set<string>();
-
-  for (const [index, serviceName] of serviceNames.entries()) {
-    if (typeof serviceName !== "string" || serviceName.length === 0) {
-      return new Err({
-        index,
-        kind: "invalid-service-entry",
-        reason: "empty-name",
-        ...(typeof serviceName === "string" && { serviceName }),
-      });
-    }
-
-    if (requestedNames.has(serviceName)) {
-      return new Err({
-        kind: "service-name-conflict",
-        scope: "requested-batch",
-        serviceName,
-      });
-    }
-
-    if (!hasOwn(services, serviceName)) {
-      return new Err({ kind: "service-not-found", serviceName });
-    }
-
-    requestedNames.add(serviceName);
-  }
-
-  return new Ok(requestedNames);
-}
-
-function findServiceDependencyConflict(
-  services: Record<string, ComposeServiceConfig>,
-  requestedNames: Set<string>
-): ComposeMutationFailure | undefined {
-  for (const [serviceName, service] of Object.entries(services)) {
-    if (requestedNames.has(serviceName)) {
-      continue;
-    }
-
-    const dependencyName = getDependencyNames(service).find((name) =>
-      requestedNames.has(name)
-    );
-    if (dependencyName !== undefined) {
-      return {
-        dependencyName,
-        kind: "service-dependency-conflict",
-        serviceName,
-      };
-    }
-  }
-
-  return undefined;
-}
-
-function collectRemovedGeneratedVolumeNames(
-  services: Record<string, ComposeServiceConfig>,
-  serviceNames: readonly string[]
-): ComposeMutationResult<Set<string>> {
-  const removedGeneratedVolumes = new Set<string>();
-  for (const serviceName of serviceNames) {
-    const service = services[serviceName];
-    if (!isRecord(service)) {
-      return new Err({ field: "services", kind: "invalid-document" });
-    }
-
-    for (const volumeName of getGeneratedVolumeNames({
-      config: service,
-      name: serviceName,
-    })) {
-      removedGeneratedVolumes.add(volumeName);
-    }
-  }
-
-  return new Ok(removedGeneratedVolumes);
-}
-
-function withoutRequestedServices(
-  services: Record<string, ComposeServiceConfig>,
-  requestedNames: Set<string>
-): Record<string, ComposeServiceConfig> {
-  return Object.fromEntries(
-    Object.entries(services).filter(
-      ([serviceName]) => !requestedNames.has(serviceName)
-    )
-  );
-}
-
-function removeUnusedGeneratedVolumes(
-  existingVolumes: Record<string, unknown> | undefined,
-  nextServices: Record<string, ComposeServiceConfig>,
-  removedGeneratedVolumes: Set<string>
-): RemovedVolumeResult {
-  if (existingVolumes === undefined) {
-    return { volumeChanged: false };
-  }
-
-  const remainingVolumeNames = new Set(
-    Object.values(nextServices).flatMap((service) =>
-      getReferencedVolumeNames(service)
-    )
-  );
-  let volumeChanged = false;
-  const nextVolumes = Object.fromEntries(
-    Object.entries(existingVolumes).filter(([volumeName, declaration]) => {
-      const shouldRemove =
-        removedGeneratedVolumes.has(volumeName) &&
-        !remainingVolumeNames.has(volumeName) &&
-        isGeneratedVolumeDeclaration(declaration);
-      if (shouldRemove) {
-        volumeChanged = true;
-      }
-
-      return !shouldRemove;
-    })
-  );
-
-  return { nextVolumes, volumeChanged };
-}
-
-function createRemovedDocument(
-  document: ComposeDocument,
-  nextServices: Record<string, ComposeServiceConfig>,
-  volumeResult: RemovedVolumeResult
-): ComposeDocument {
-  const { nextVolumes, volumeChanged } = volumeResult;
-  const hasRemainingVolumes =
-    nextVolumes !== undefined && Object.keys(nextVolumes).length > 0;
-  const baseDocument =
-    volumeChanged && !hasRemainingVolumes ? withoutVolumes(document) : document;
-
-  return {
-    ...baseDocument,
-    services: nextServices,
-    ...(nextVolumes !== undefined && (!volumeChanged || hasRemainingVolumes)
-      ? { volumes: nextVolumes }
-      : {}),
-  };
-}
-
-function getDependencyNames(service: ComposeServiceConfig): string[] {
-  if (!isRecord(service) || service.depends_on === undefined) {
-    return [];
-  }
-
-  if (Array.isArray(service.depends_on)) {
-    return service.depends_on.filter(
-      (dependency): dependency is string => typeof dependency === "string"
-    );
-  }
-
-  if (isRecord(service.depends_on)) {
-    return Object.keys(service.depends_on);
-  }
-
-  return [];
-}
-
-function isGeneratedVolumeDeclaration(value: unknown): boolean {
-  return isRecord(value) && Object.keys(value).length === 0;
-}
-
-function withoutVolumes(document: ComposeDocument): ComposeDocument {
-  const { volumes: _volumes, ...documentWithoutVolumes } = document;
-  return documentWithoutVolumes;
-}
-
-function getGeneratedVolumeNames(entry: ComposeServiceEntry): string[] {
-  const config = isRecord(entry.config) ? entry.config : undefined;
-  const volumes = config?.volumes;
-  if (!Array.isArray(volumes)) {
-    return [];
-  }
-
-  const generatedVolumeName = `${entry.name}_data`;
-
-  return volumes.flatMap((mount) => {
-    const source = getMountSource(mount);
-    return source === generatedVolumeName ? [source] : [];
-  });
-}
-
-function getReferencedVolumeNames(service: ComposeServiceConfig): string[] {
-  if (!(isRecord(service) && Array.isArray(service.volumes))) {
-    return [];
-  }
-
-  return service.volumes.flatMap((mount) => {
-    const source = getMountSource(mount);
-    return source !== undefined && source !== "" ? [source] : [];
-  });
-}
-
-function getMountSource(mount: unknown): string | undefined {
-  if (typeof mount === "string") {
-    const separatorIndex = mount.indexOf(":");
-    if (separatorIndex <= 0) {
-      return undefined;
-    }
-
-    const source = mount.slice(0, separatorIndex);
-    if (
-      source.startsWith("/") ||
-      source.startsWith("./") ||
-      source.startsWith("../") ||
-      source.startsWith("~") ||
-      WINDOWS_PATH_PATTERN.test(mount)
-    ) {
-      return undefined;
-    }
-
-    return source;
-  }
-
-  if (!isRecord(mount) || typeof mount.source !== "string") {
-    return undefined;
-  }
-
-  if (mount.type !== undefined && mount.type !== "volume") {
-    return undefined;
-  }
-
-  return mount.source;
-}
-
-function hasOwn(
-  value: Record<string, unknown> | undefined,
-  key: string
-): boolean {
-  return value !== undefined && Object.hasOwn(value, key);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
@@ -28,6 +28,53 @@ import type {
   ComposeFileSystem,
 } from "./compose-file-adapter";
 
+async function createTempDirectory(): Promise<string> {
+  return await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-adapter-"));
+}
+
+async function removeTempDirectory(cwd: string): Promise<void> {
+  await rm(cwd, { force: true, recursive: true });
+}
+
+function createFileSystem(
+  overrides: Partial<ComposeFileSystem> = {}
+): ComposeFileSystem {
+  return {
+    chmod,
+    link,
+    readFile: async (filePath) => await readFile(filePath, "utf-8"),
+    rename,
+    stat: lstat,
+    unlink,
+    writeFile: async (filePath, data, options) => {
+      await writeFile(filePath, data, options);
+    },
+    ...overrides,
+  };
+}
+
+async function readComposeFailure(source: string): Promise<{
+  contents: string;
+  error: ComposeFileFailure | undefined;
+}> {
+  const cwd = await createTempDirectory();
+  const composePath = path.join(cwd, "compose.yaml");
+
+  try {
+    await writeFile(composePath, source);
+
+    const result = await readComposeDocument(cwd, "compose.yaml");
+    const error = result.isErr() ? result.error : undefined;
+
+    return {
+      contents: await readFile(composePath, "utf-8"),
+      error,
+    };
+  } finally {
+    await removeTempDirectory(cwd);
+  }
+}
+
 test("discovers every supported Compose candidate without selecting one", async () => {
   const cwd = await createTempDirectory();
 
@@ -707,50 +754,3 @@ test("reports replacement failures without leaving a temporary file", async () =
     await removeTempDirectory(cwd);
   }
 });
-
-async function readComposeFailure(source: string): Promise<{
-  contents: string;
-  error: ComposeFileFailure | undefined;
-}> {
-  const cwd = await createTempDirectory();
-  const composePath = path.join(cwd, "compose.yaml");
-
-  try {
-    await writeFile(composePath, source);
-
-    const result = await readComposeDocument(cwd, "compose.yaml");
-    const error = result.isErr() ? result.error : undefined;
-
-    return {
-      contents: await readFile(composePath, "utf-8"),
-      error,
-    };
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-}
-
-async function createTempDirectory(): Promise<string> {
-  return await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-adapter-"));
-}
-
-function createFileSystem(
-  overrides: Partial<ComposeFileSystem> = {}
-): ComposeFileSystem {
-  return {
-    chmod,
-    link,
-    readFile: async (filePath) => await readFile(filePath, "utf-8"),
-    rename,
-    stat: lstat,
-    unlink,
-    writeFile: async (filePath, data, options) => {
-      await writeFile(filePath, data, options);
-    },
-    ...overrides,
-  };
-}
-
-async function removeTempDirectory(cwd: string): Promise<void> {
-  await rm(cwd, { force: true, recursive: true });
-}

--- a/packages/cli/src/commands/docker/helpers/compose-file-adapter.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-file-adapter.ts
@@ -138,6 +138,161 @@ const nodeFileSystem: ComposeFileSystem = {
   },
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return isRecord(error) && error.code === "ENOENT";
+}
+
+function isExistingFileError(error: unknown): boolean {
+  return isRecord(error) && error.code === "EEXIST";
+}
+
+function isSymbolicLink(stats: ComposeFileStats): boolean {
+  return stats.isSymbolicLink?.() ?? false;
+}
+
+function sameRevisionMetadata(
+  first: Pick<ComposeFileStats, "dev" | "ino" | "mode" | "mtimeMs" | "size">,
+  second: Pick<ComposeFileStats, "dev" | "ino" | "mode" | "mtimeMs" | "size">
+): boolean {
+  return (
+    first.dev === second.dev &&
+    first.ino === second.ino &&
+    first.mode === second.mode &&
+    first.mtimeMs === second.mtimeMs &&
+    first.size === second.size
+  );
+}
+
+function createFileRevision(
+  stats: ComposeFileStats,
+  source: string
+): ComposeFileRevision {
+  return {
+    contentHash: createHash("sha256").update(source).digest("hex"),
+    dev: stats.dev,
+    ino: stats.ino,
+    mode: stats.mode,
+    mtimeMs: stats.mtimeMs,
+    size: stats.size,
+  };
+}
+
+function sameRevision(
+  first: ComposeFileRevision,
+  second: ComposeFileRevision
+): boolean {
+  return (
+    first.contentHash === second.contentHash &&
+    sameRevisionMetadata(first, second)
+  );
+}
+
+async function verifyRevision(
+  filePath: string,
+  fileName: ComposeFileName,
+  revision: ComposeFileRevision,
+  fileSystem: ComposeFileReader,
+  knownStats?: ComposeFileStats
+): Promise<ComposeFileFailure | undefined> {
+  let stats = knownStats;
+
+  if (!stats) {
+    try {
+      stats = await fileSystem.stat(filePath);
+    } catch {
+      return { fileName, kind: "stale-document" };
+    }
+  }
+
+  if (isSymbolicLink(stats)) {
+    return { fileName, kind: "symlinked-document" };
+  }
+
+  if (!(stats.isFile() && sameRevisionMetadata(stats, revision))) {
+    return { fileName, kind: "stale-document" };
+  }
+
+  let source: string;
+  try {
+    source = await fileSystem.readFile(filePath);
+  } catch {
+    return { fileName, kind: "read-failure" };
+  }
+
+  return sameRevision(revision, createFileRevision(stats, source))
+    ? undefined
+    : { fileName, kind: "stale-document" };
+}
+
+function validateComposeDocument(
+  value: unknown,
+  fileName: ComposeFileName
+):
+  | Ok<ComposeDocument, ComposeFileFailure>
+  | Err<ComposeDocument, ComposeFileFailure> {
+  if (!isRecord(value)) {
+    return new Err({ field: "root", fileName, kind: "invalid-document" });
+  }
+
+  if (value.services !== undefined) {
+    if (!isRecord(value.services)) {
+      return new Err({ field: "services", fileName, kind: "invalid-document" });
+    }
+
+    for (const [serviceName, service] of Object.entries(value.services)) {
+      if (!isRecord(service)) {
+        return new Err({
+          field: "services",
+          fileName,
+          kind: "invalid-document",
+          serviceName,
+        });
+      }
+    }
+  }
+
+  if (value.volumes !== undefined && !isRecord(value.volumes)) {
+    return new Err({ field: "volumes", fileName, kind: "invalid-document" });
+  }
+
+  return new Ok(value);
+}
+
+async function getExistingTargetFailure(
+  filePath: string,
+  fileName: ComposeFileName,
+  fileSystem: ComposeFileReader
+): Promise<
+  Extract<
+    ComposeFileFailure,
+    { kind: "symlinked-document" | "creation-conflict" }
+  >
+> {
+  try {
+    const stats = await fileSystem.stat(filePath);
+    return isSymbolicLink(stats)
+      ? { fileName, kind: "symlinked-document" }
+      : { fileName, kind: "creation-conflict" };
+  } catch {
+    return { fileName, kind: "creation-conflict" };
+  }
+}
+
+async function removeTemporaryFile(
+  filePath: string,
+  fileSystem: ComposeFileSystem
+): Promise<void> {
+  try {
+    await fileSystem.unlink(filePath);
+  } catch {
+    // Preserve the original file even when temporary-file cleanup fails.
+  }
+}
+
 export async function discoverComposeFiles(
   cwd: string,
   fileSystem: ComposeFileReader = nodeFileSystem
@@ -419,159 +574,4 @@ export async function writeComposeDocument(
       await removeTemporaryFile(temporaryPath, fileSystem);
     }
   }
-}
-
-function validateComposeDocument(
-  value: unknown,
-  fileName: ComposeFileName
-):
-  | Ok<ComposeDocument, ComposeFileFailure>
-  | Err<ComposeDocument, ComposeFileFailure> {
-  if (!isRecord(value)) {
-    return new Err({ field: "root", fileName, kind: "invalid-document" });
-  }
-
-  if (value.services !== undefined) {
-    if (!isRecord(value.services)) {
-      return new Err({ field: "services", fileName, kind: "invalid-document" });
-    }
-
-    for (const [serviceName, service] of Object.entries(value.services)) {
-      if (!isRecord(service)) {
-        return new Err({
-          field: "services",
-          fileName,
-          kind: "invalid-document",
-          serviceName,
-        });
-      }
-    }
-  }
-
-  if (value.volumes !== undefined && !isRecord(value.volumes)) {
-    return new Err({ field: "volumes", fileName, kind: "invalid-document" });
-  }
-
-  return new Ok(value);
-}
-
-function isMissingFileError(error: unknown): boolean {
-  return isRecord(error) && error.code === "ENOENT";
-}
-
-function isExistingFileError(error: unknown): boolean {
-  return isRecord(error) && error.code === "EEXIST";
-}
-
-function isSymbolicLink(stats: ComposeFileStats): boolean {
-  return stats.isSymbolicLink?.() ?? false;
-}
-
-function createFileRevision(
-  stats: ComposeFileStats,
-  source: string
-): ComposeFileRevision {
-  return {
-    contentHash: createHash("sha256").update(source).digest("hex"),
-    dev: stats.dev,
-    ino: stats.ino,
-    mode: stats.mode,
-    mtimeMs: stats.mtimeMs,
-    size: stats.size,
-  };
-}
-
-async function verifyRevision(
-  filePath: string,
-  fileName: ComposeFileName,
-  revision: ComposeFileRevision,
-  fileSystem: ComposeFileReader,
-  knownStats?: ComposeFileStats
-): Promise<ComposeFileFailure | undefined> {
-  let stats = knownStats;
-
-  if (!stats) {
-    try {
-      stats = await fileSystem.stat(filePath);
-    } catch {
-      return { fileName, kind: "stale-document" };
-    }
-  }
-
-  if (isSymbolicLink(stats)) {
-    return { fileName, kind: "symlinked-document" };
-  }
-
-  if (!(stats.isFile() && sameRevisionMetadata(stats, revision))) {
-    return { fileName, kind: "stale-document" };
-  }
-
-  let source: string;
-  try {
-    source = await fileSystem.readFile(filePath);
-  } catch {
-    return { fileName, kind: "read-failure" };
-  }
-
-  return sameRevision(revision, createFileRevision(stats, source))
-    ? undefined
-    : { fileName, kind: "stale-document" };
-}
-
-function sameRevisionMetadata(
-  first: Pick<ComposeFileStats, "dev" | "ino" | "mode" | "mtimeMs" | "size">,
-  second: Pick<ComposeFileStats, "dev" | "ino" | "mode" | "mtimeMs" | "size">
-): boolean {
-  return (
-    first.dev === second.dev &&
-    first.ino === second.ino &&
-    first.mode === second.mode &&
-    first.mtimeMs === second.mtimeMs &&
-    first.size === second.size
-  );
-}
-
-function sameRevision(
-  first: ComposeFileRevision,
-  second: ComposeFileRevision
-): boolean {
-  return (
-    first.contentHash === second.contentHash &&
-    sameRevisionMetadata(first, second)
-  );
-}
-
-async function getExistingTargetFailure(
-  filePath: string,
-  fileName: ComposeFileName,
-  fileSystem: ComposeFileReader
-): Promise<
-  Extract<
-    ComposeFileFailure,
-    { kind: "symlinked-document" | "creation-conflict" }
-  >
-> {
-  try {
-    const stats = await fileSystem.stat(filePath);
-    return isSymbolicLink(stats)
-      ? { fileName, kind: "symlinked-document" }
-      : { fileName, kind: "creation-conflict" };
-  } catch {
-    return { fileName, kind: "creation-conflict" };
-  }
-}
-
-async function removeTemporaryFile(
-  filePath: string,
-  fileSystem: ComposeFileSystem
-): Promise<void> {
-  try {
-    await fileSystem.unlink(filePath);
-  } catch {
-    // Preserve the original file even when temporary-file cleanup fails.
-  }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/cli/src/commands/docker/helpers/format-compose-file-failure.ts
+++ b/packages/cli/src/commands/docker/helpers/format-compose-file-failure.ts
@@ -1,5 +1,44 @@
 import type { ComposeFileFailure } from "./compose-file-adapter";
 
+function formatParseFailure(
+  fileName: string,
+  reason: "empty-document" | "invalid-yaml" | "multi-document" | "duplicate-key"
+): string {
+  switch (reason) {
+    case "empty-document": {
+      return `Docker Compose file is empty: ${fileName}`;
+    }
+    case "multi-document": {
+      return `Docker Compose file must contain exactly one YAML document: ${fileName}`;
+    }
+    case "duplicate-key": {
+      return `Docker Compose file contains duplicate YAML keys: ${fileName}`;
+    }
+    case "invalid-yaml": {
+      return `Failed to parse existing Docker Compose file: ${fileName}`;
+    }
+    default: {
+      return `Failed to parse Docker Compose file: ${fileName}`;
+    }
+  }
+}
+
+function formatInvalidDocumentFailure(
+  fileName: string,
+  field: "root" | "services" | "volumes",
+  serviceName?: string
+): string {
+  if (field === "root") {
+    return `Docker Compose document must use a mapping root: ${fileName}`;
+  }
+
+  if (field === "services" && serviceName !== undefined && serviceName !== "") {
+    return `Docker Compose service "${serviceName}" must use a mapping: ${fileName}`;
+  }
+
+  return `Docker Compose document has an invalid ${field} collection: ${fileName}`;
+}
+
 export function formatComposeFileFailure(failure: ComposeFileFailure): string {
   switch (failure.kind) {
     case "discovery-failure": {
@@ -40,43 +79,4 @@ export function formatComposeFileFailure(failure: ComposeFileFailure): string {
       return "Docker Compose file operation failed.";
     }
   }
-}
-
-function formatParseFailure(
-  fileName: string,
-  reason: "empty-document" | "invalid-yaml" | "multi-document" | "duplicate-key"
-): string {
-  switch (reason) {
-    case "empty-document": {
-      return `Docker Compose file is empty: ${fileName}`;
-    }
-    case "multi-document": {
-      return `Docker Compose file must contain exactly one YAML document: ${fileName}`;
-    }
-    case "duplicate-key": {
-      return `Docker Compose file contains duplicate YAML keys: ${fileName}`;
-    }
-    case "invalid-yaml": {
-      return `Failed to parse existing Docker Compose file: ${fileName}`;
-    }
-    default: {
-      return `Failed to parse Docker Compose file: ${fileName}`;
-    }
-  }
-}
-
-function formatInvalidDocumentFailure(
-  fileName: string,
-  field: "root" | "services" | "volumes",
-  serviceName?: string
-): string {
-  if (field === "root") {
-    return `Docker Compose document must use a mapping root: ${fileName}`;
-  }
-
-  if (field === "services" && serviceName !== undefined && serviceName !== "") {
-    return `Docker Compose service "${serviceName}" must use a mapping: ${fileName}`;
-  }
-
-  return `Docker Compose document has an invalid ${field} collection: ${fileName}`;
 }

--- a/packages/cli/src/commands/docker/helpers/init-docker.test.ts
+++ b/packages/cli/src/commands/docker/helpers/init-docker.test.ts
@@ -27,6 +27,22 @@ const promptMocks = vi.hoisted(() => ({
 
 vi.mock(import("~/utils/prompts"), () => promptMocks);
 
+async function createComposeFixture(
+  overrides: { services?: string } = {}
+): Promise<string> {
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
+  const services =
+    overrides.services ??
+    "  app:\n    image: example/app\n    labels:\n      com.example.owner: user";
+
+  await writeFile(
+    path.join(cwd, "compose.yaml"),
+    `name: example\nservices:\n${services}\nvolumes:\n  shared_data:\n    labels:\n      com.example.owner: user\n`
+  );
+
+  return cwd;
+}
+
 test("initDocker writes the transformed document after service selection", async () => {
   const cwd = await createComposeFixture();
 
@@ -194,19 +210,3 @@ test("initDocker prompts for a supported filename when no Compose file exists", 
     await rm(cwd, { force: true, recursive: true });
   }
 });
-
-async function createComposeFixture(
-  overrides: { services?: string } = {}
-): Promise<string> {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
-  const services =
-    overrides.services ??
-    "  app:\n    image: example/app\n    labels:\n      com.example.owner: user";
-
-  await writeFile(
-    path.join(cwd, "compose.yaml"),
-    `name: example\nservices:\n${services}\nvolumes:\n  shared_data:\n    labels:\n      com.example.owner: user\n`
-  );
-
-  return cwd;
-}

--- a/packages/cli/src/commands/docker/helpers/init-docker.ts
+++ b/packages/cli/src/commands/docker/helpers/init-docker.ts
@@ -31,6 +31,36 @@ export interface InitDockerResult {
   connectionConfigs: ConnectionConfig[];
 }
 
+function formatComposeMutationFailure(failure: ComposeMutationFailure): string {
+  switch (failure.kind) {
+    case "empty-service-batch": {
+      return "No Docker services were selected.";
+    }
+    case "no-services": {
+      return "No services found in the compose file.";
+    }
+    case "invalid-document": {
+      return `The Docker Compose document has an invalid ${failure.field} collection.`;
+    }
+    case "invalid-service-entry": {
+      return `The Docker service entry at position ${failure.index + 1} is invalid.`;
+    }
+    case "service-name-conflict": {
+      return `The Docker service name "${failure.serviceName}" already exists in the ${failure.scope === "existing-document" ? "Compose document" : "requested batch"}.`;
+    }
+    case "service-not-found": {
+      return `The Docker service "${failure.serviceName}" was not found in the Compose document.`;
+    }
+    case "service-dependency-conflict": {
+      return `Cannot remove "${failure.dependencyName}" because the remaining service "${failure.serviceName}" depends on it.`;
+    }
+    default: {
+      const _exhaustive: never = failure;
+      return _exhaustive;
+    }
+  }
+}
+
 export async function initDocker(options: InitDockerProps) {
   const discoveryResult = await discoverComposeFiles(options.cwd);
 
@@ -140,34 +170,4 @@ export async function initDocker(options: InitDockerProps) {
   }
 
   return new Ok({ connectionConfigs, imageConfigs });
-}
-
-function formatComposeMutationFailure(failure: ComposeMutationFailure): string {
-  switch (failure.kind) {
-    case "empty-service-batch": {
-      return "No Docker services were selected.";
-    }
-    case "no-services": {
-      return "No services found in the compose file.";
-    }
-    case "invalid-document": {
-      return `The Docker Compose document has an invalid ${failure.field} collection.`;
-    }
-    case "invalid-service-entry": {
-      return `The Docker service entry at position ${failure.index + 1} is invalid.`;
-    }
-    case "service-name-conflict": {
-      return `The Docker service name "${failure.serviceName}" already exists in the ${failure.scope === "existing-document" ? "Compose document" : "requested batch"}.`;
-    }
-    case "service-not-found": {
-      return `The Docker service "${failure.serviceName}" was not found in the Compose document.`;
-    }
-    case "service-dependency-conflict": {
-      return `Cannot remove "${failure.dependencyName}" because the remaining service "${failure.serviceName}" depends on it.`;
-    }
-    default: {
-      const _exhaustive: never = failure;
-      return _exhaustive;
-    }
-  }
 }

--- a/packages/cli/src/commands/docker/init.test.ts
+++ b/packages/cli/src/commands/docker/init.test.ts
@@ -45,6 +45,12 @@ vi.mock(import("~/utils/handle-error"), () => ({
 
 vi.mock(import("~/utils/prompts"), () => promptMocks);
 
+async function createComposeFixture(): Promise<string> {
+  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-docker-init-"));
+  await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
+  return cwd;
+}
+
 test("init reports an environment failure after the Compose file is written", async () => {
   const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-docker-init-"));
   const envPath = path.join(cwd, "env-directory");
@@ -188,9 +194,3 @@ test("init succeeds without environment changes when synchronization is declined
     await rm(cwd, { force: true, recursive: true });
   }
 });
-
-async function createComposeFixture(): Promise<string> {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-docker-init-"));
-  await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
-  return cwd;
-}

--- a/packages/cli/src/commands/docker/init.ts
+++ b/packages/cli/src/commands/docker/init.ts
@@ -25,36 +25,15 @@ interface InitOptions {
   skipConflicts: boolean;
 }
 
-export const init = new Command()
-  .name("init")
-  .description("Init a Docker Compose")
-  .option(
-    "-c, --cwd <cwd>",
-    "The working directory. Defaults to the current directory.",
-    process.cwd()
-  )
-  .option("--env-path <path>", "Custom path for .env file")
-  .option("--skip-conflicts", "Skip existing env vars without prompting", false)
-  .action(async (options: InitOptions) => {
-    const optionsResult = await parseOptions(options);
+async function parseOptions(options: InitOptions) {
+  if (!(await access(options.cwd))) {
+    return new Err(`The directory ${options.cwd} does not exist.`);
+  }
 
-    if (optionsResult.isErr()) {
-      handleError(optionsResult.error);
-    }
-
-    const { initDocker } = await import("./helpers/init-docker");
-    const initResult = await initDocker(optionsResult.value);
-
-    if (initResult.isErr()) {
-      handleError(initResult.error);
-    }
-
-    const { imageConfigs, connectionConfigs } = initResult.value;
-
-    logConnectionStrings(connectionConfigs);
-    await syncEnvironment(optionsResult.value.cwd, options, connectionConfigs);
-    logImageLinks(imageConfigs);
+  return new Ok({
+    cwd: options.cwd,
   });
+}
 
 function logConnectionStrings(connectionConfigs: ConnectionConfig[]): void {
   logger.break();
@@ -73,35 +52,18 @@ function logConnectionStrings(connectionConfigs: ConnectionConfig[]): void {
   logger.break();
 }
 
-async function syncEnvironment(
-  cwd: string,
-  options: InitOptions,
-  connectionConfigs: ConnectionConfig[]
-): Promise<void> {
-  const writeToEnv = await enhancedConfirm({
-    initialValue: true,
-    message: "Write connection strings to .env file?",
-  });
-  if (!writeToEnv) {
-    return;
+function logImageLinks(imageConfigs: DatabaseImageConfig[]): void {
+  logger.break();
+  logger.info(
+    "Check out the Docker Image documentation to learn more about how to use it."
+  );
+
+  for (const { repository, namespace } of imageConfigs) {
+    const repositoryLink = getRepositoryLink(repository, namespace);
+    logger.info(`- ${repository}: ${repositoryLink}`);
   }
 
-  const envPath = options.envPath ?? `${cwd}/.env`;
-  const newVars = getAllEnvVars(connectionConfigs);
-  const existingVarsResult = await readEnvFile(envPath);
-  if (existingVarsResult.isErr()) {
-    handleError(formatEnvironmentSyncFailure(existingVarsResult.error));
-  }
-
-  const existingVars = existingVarsResult.value;
-  await (existingVars === null
-    ? createEnvFile(envPath, newVars)
-    : updateEnvFile(envPath, newVars, existingVars, options.skipConflicts));
-
-  const gitignoreResult = await addToGitignore(cwd, ".env");
-  if (gitignoreResult.isErr()) {
-    handleError(formatEnvironmentSyncFailure(gitignoreResult.error));
-  }
+  logger.break();
 }
 
 async function createEnvFile(
@@ -176,26 +138,64 @@ async function updateEnvFile(
   }
 }
 
-function logImageLinks(imageConfigs: DatabaseImageConfig[]): void {
-  logger.break();
-  logger.info(
-    "Check out the Docker Image documentation to learn more about how to use it."
-  );
-
-  for (const { repository, namespace } of imageConfigs) {
-    const repositoryLink = getRepositoryLink(repository, namespace);
-    logger.info(`- ${repository}: ${repositoryLink}`);
-  }
-
-  logger.break();
-}
-
-async function parseOptions(options: InitOptions) {
-  if (!(await access(options.cwd))) {
-    return new Err(`The directory ${options.cwd} does not exist.`);
-  }
-
-  return new Ok({
-    cwd: options.cwd,
+async function syncEnvironment(
+  cwd: string,
+  options: InitOptions,
+  connectionConfigs: ConnectionConfig[]
+): Promise<void> {
+  const writeToEnv = await enhancedConfirm({
+    initialValue: true,
+    message: "Write connection strings to .env file?",
   });
+  if (!writeToEnv) {
+    return;
+  }
+
+  const envPath = options.envPath ?? `${cwd}/.env`;
+  const newVars = getAllEnvVars(connectionConfigs);
+  const existingVarsResult = await readEnvFile(envPath);
+  if (existingVarsResult.isErr()) {
+    handleError(formatEnvironmentSyncFailure(existingVarsResult.error));
+  }
+
+  const existingVars = existingVarsResult.value;
+  await (existingVars === null
+    ? createEnvFile(envPath, newVars)
+    : updateEnvFile(envPath, newVars, existingVars, options.skipConflicts));
+
+  const gitignoreResult = await addToGitignore(cwd, ".env");
+  if (gitignoreResult.isErr()) {
+    handleError(formatEnvironmentSyncFailure(gitignoreResult.error));
+  }
 }
+
+export const init = new Command()
+  .name("init")
+  .description("Init a Docker Compose")
+  .option(
+    "-c, --cwd <cwd>",
+    "The working directory. Defaults to the current directory.",
+    process.cwd()
+  )
+  .option("--env-path <path>", "Custom path for .env file")
+  .option("--skip-conflicts", "Skip existing env vars without prompting", false)
+  .action(async (options: InitOptions) => {
+    const optionsResult = await parseOptions(options);
+
+    if (optionsResult.isErr()) {
+      handleError(optionsResult.error);
+    }
+
+    const { initDocker } = await import("./helpers/init-docker");
+    const initResult = await initDocker(optionsResult.value);
+
+    if (initResult.isErr()) {
+      handleError(initResult.error);
+    }
+
+    const { imageConfigs, connectionConfigs } = initResult.value;
+
+    logConnectionStrings(connectionConfigs);
+    await syncEnvironment(optionsResult.value.cwd, options, connectionConfigs);
+    logImageLinks(imageConfigs);
+  });

--- a/packages/cli/src/commands/docker/remove.ts
+++ b/packages/cli/src/commands/docker/remove.ts
@@ -34,6 +34,45 @@ interface RemoveOptions {
   envPath?: string;
 }
 
+async function parseOptions(options: RemoveOptions) {
+  if (!(await access(options.cwd))) {
+    return new Err(`The directory ${options.cwd} does not exist.`);
+  }
+
+  return new Ok({
+    cwd: options.cwd,
+  });
+}
+
+function formatComposeMutationFailure(failure: ComposeMutationFailure): string {
+  switch (failure.kind) {
+    case "empty-service-batch": {
+      return "No Docker services were selected.";
+    }
+    case "no-services": {
+      return "No services found in the compose file.";
+    }
+    case "invalid-document": {
+      return `The Docker Compose document has an invalid ${failure.field} collection.`;
+    }
+    case "invalid-service-entry": {
+      return `The Docker service selection at position ${failure.index + 1} is invalid.`;
+    }
+    case "service-name-conflict": {
+      return `The Docker service name "${failure.serviceName}" appears more than once in the requested batch.`;
+    }
+    case "service-not-found": {
+      return `The Docker service "${failure.serviceName}" was not found in the Compose document.`;
+    }
+    case "service-dependency-conflict": {
+      return `Cannot remove "${failure.dependencyName}" because the remaining service "${failure.serviceName}" depends on it.`;
+    }
+    default: {
+      return "The Docker service selection could not be applied.";
+    }
+  }
+}
+
 export const remove = new Command()
   .name("remove")
   .description("Remove services from Docker Compose")
@@ -188,42 +227,3 @@ export const remove = new Command()
 
     logger.break();
   });
-
-async function parseOptions(options: RemoveOptions) {
-  if (!(await access(options.cwd))) {
-    return new Err(`The directory ${options.cwd} does not exist.`);
-  }
-
-  return new Ok({
-    cwd: options.cwd,
-  });
-}
-
-function formatComposeMutationFailure(failure: ComposeMutationFailure): string {
-  switch (failure.kind) {
-    case "empty-service-batch": {
-      return "No Docker services were selected.";
-    }
-    case "no-services": {
-      return "No services found in the compose file.";
-    }
-    case "invalid-document": {
-      return `The Docker Compose document has an invalid ${failure.field} collection.`;
-    }
-    case "invalid-service-entry": {
-      return `The Docker service selection at position ${failure.index + 1} is invalid.`;
-    }
-    case "service-name-conflict": {
-      return `The Docker service name "${failure.serviceName}" appears more than once in the requested batch.`;
-    }
-    case "service-not-found": {
-      return `The Docker service "${failure.serviceName}" was not found in the Compose document.`;
-    }
-    case "service-dependency-conflict": {
-      return `Cannot remove "${failure.dependencyName}" because the remaining service "${failure.serviceName}" depends on it.`;
-    }
-    default: {
-      return "The Docker service selection could not be applied.";
-    }
-  }
-}


### PR DESCRIPTION
Enable no-use-before-define for Docker command modules and move helper declarations ahead of their callers without changing behavior.

Closes #73

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>