### PR TITLE
chore(lint): finish use-before-define migration

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -19,16 +19,6 @@ export default defineConfig({
     "**/.opencode/**",
     "**/.turbo/**",
   ],
-  overrides: [
-    {
-      // Keep the migration scoped while the remaining CLI baseline is deferred.
-      files: ["packages/cli/src/commands/docker/**/*.ts"],
-      rules: {
-        "no-use-before-define": "error",
-      },
-    },
-  ],
-
   rules: {
     "sort-keys": "off",
 
@@ -43,7 +33,7 @@ export default defineConfig({
     complexity: "error",
     "no-warning-comments": "error",
     "no-await-in-loop": "error",
-    "no-use-before-define": "off",
+    "no-use-before-define": "error",
     "typescript/no-dynamic-delete": "error",
     "prefer-destructuring": "error",
     "require-unicode-regexp": "error",

--- a/packages/cli/src/commands/biome/init.ts
+++ b/packages/cli/src/commands/biome/init.ts
@@ -9,6 +9,14 @@ export interface InitOptions {
   cwd: string;
 }
 
+async function parseOptions(options: InitOptions) {
+  if (!(await access(options.cwd))) {
+    return new Err(`The directory ${options.cwd} does not exist.`);
+  }
+
+  return new Ok(options);
+}
+
 export const init = new Command()
   .name("init")
   .description("Init Biome")
@@ -39,11 +47,3 @@ export const init = new Command()
     logger.info("https://biomejs.dev/guides/getting-started/#usage");
     logger.break();
   });
-
-async function parseOptions(options: InitOptions) {
-  if (!(await access(options.cwd))) {
-    return new Err(`The directory ${options.cwd} does not exist.`);
-  }
-
-  return new Ok(options);
-}

--- a/packages/cli/src/commands/biome/remove.ts
+++ b/packages/cli/src/commands/biome/remove.ts
@@ -9,6 +9,14 @@ export interface RemoveOptions {
   cwd: string;
 }
 
+async function parseOptions(options: RemoveOptions) {
+  if (!(await access(options.cwd))) {
+    return new Err(`The directory ${options.cwd} does not exist.`);
+  }
+
+  return new Ok(options);
+}
+
 export const remove = new Command()
   .name("remove")
   .description("Remove Biome")
@@ -35,11 +43,3 @@ export const remove = new Command()
     logger.info("Biome has been removed from your project.");
     logger.break();
   });
-
-async function parseOptions(options: RemoveOptions) {
-  if (!(await access(options.cwd))) {
-    return new Err(`The directory ${options.cwd} does not exist.`);
-  }
-
-  return new Ok(options);
-}

--- a/packages/cli/src/commands/drizzle/init.ts
+++ b/packages/cli/src/commands/drizzle/init.ts
@@ -21,6 +21,25 @@ export type ParsedInitOptions = Omit<InitOptions, "database"> & {
   database?: DrizzleDatabase;
 };
 
+async function parseOptions(options: InitOptions) {
+  if (!(await access(options.cwd))) {
+    return new Err(`The directory ${options.cwd} does not exist.`);
+  }
+
+  const result = drizzleDatabaseSchema.safeParse(options.database);
+
+  if (!result.success) {
+    return new Err(formatZodErrors(result.error));
+  }
+
+  return new Ok({
+    cwd: options.cwd,
+    database: result.data,
+    withModel: options.withModel,
+    withScripts: options.withScripts,
+  });
+}
+
 export const init = new Command()
   .name("init")
   .description("Init Drizzle ORM")
@@ -62,22 +81,3 @@ export const init = new Command()
     logger.info(adapterDocs);
     logger.break();
   });
-
-async function parseOptions(options: InitOptions) {
-  if (!(await access(options.cwd))) {
-    return new Err(`The directory ${options.cwd} does not exist.`);
-  }
-
-  const result = drizzleDatabaseSchema.safeParse(options.database);
-
-  if (!result.success) {
-    return new Err(formatZodErrors(result.error));
-  }
-
-  return new Ok({
-    cwd: options.cwd,
-    database: result.data,
-    withModel: options.withModel,
-    withScripts: options.withScripts,
-  });
-}

--- a/packages/cli/src/commands/gitignore/init.ts
+++ b/packages/cli/src/commands/gitignore/init.ts
@@ -9,6 +9,14 @@ export interface InitOptions {
   cwd: string;
 }
 
+async function parseOptions(options: InitOptions) {
+  if (!(await access(options.cwd))) {
+    return new Err(`The directory ${options.cwd} does not exist.`);
+  }
+
+  return new Ok(options);
+}
+
 export const init = new Command()
   .name("init")
   .description("Init .gitignore")
@@ -39,11 +47,3 @@ export const init = new Command()
     logger.info("https://git-scm.com/docs/gitignore");
     logger.break();
   });
-
-async function parseOptions(options: InitOptions) {
-  if (!(await access(options.cwd))) {
-    return new Err(`The directory ${options.cwd} does not exist.`);
-  }
-
-  return new Ok(options);
-}

--- a/packages/cli/src/commands/prisma/init.ts
+++ b/packages/cli/src/commands/prisma/init.ts
@@ -20,6 +20,25 @@ export type ParsedInitOptions = Omit<InitOptions, "database"> & {
   database?: PrismaDatabase;
 };
 
+async function parseOptions(options: InitOptions) {
+  if (!(await access(options.cwd))) {
+    return new Err(`The directory ${options.cwd} does not exist.`);
+  }
+
+  const result = prismaDatabaseSchema.safeParse(options.database);
+
+  if (!result.success) {
+    return new Err(formatZodErrors(result.error));
+  }
+
+  return new Ok({
+    cwd: options.cwd,
+    database: result.data,
+    withModel: options.withModel,
+    withScripts: options.withScripts,
+  });
+}
+
 export const init = new Command()
   .name("init")
   .description("Init Prisma ORM")
@@ -53,22 +72,3 @@ export const init = new Command()
     logger.info("https://www.prisma.io/docs");
     logger.break();
   });
-
-async function parseOptions(options: InitOptions) {
-  if (!(await access(options.cwd))) {
-    return new Err(`The directory ${options.cwd} does not exist.`);
-  }
-
-  const result = prismaDatabaseSchema.safeParse(options.database);
-
-  if (!result.success) {
-    return new Err(formatZodErrors(result.error));
-  }
-
-  return new Ok({
-    cwd: options.cwd,
-    database: result.data,
-    withModel: options.withModel,
-    withScripts: options.withScripts,
-  });
-}

--- a/packages/cli/src/commands/typescript/init.ts
+++ b/packages/cli/src/commands/typescript/init.ts
@@ -9,6 +9,14 @@ export interface InitOptions {
   cwd: string;
 }
 
+async function parseOptions(options: InitOptions) {
+  if (!(await access(options.cwd))) {
+    return new Err(`The directory ${options.cwd} does not exist.`);
+  }
+
+  return new Ok(options);
+}
+
 export const init = new Command()
   .name("init")
   .description("Init TypeScript")
@@ -39,11 +47,3 @@ export const init = new Command()
     logger.info("https://www.typescriptlang.org/docs");
     logger.break();
   });
-
-async function parseOptions(options: InitOptions) {
-  if (!(await access(options.cwd))) {
-    return new Err(`The directory ${options.cwd} does not exist.`);
-  }
-
-  return new Ok(options);
-}


### PR DESCRIPTION
Enable the rule globally after migrating the remaining CLI command parsers.

Closes #74

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>