### PR TITLE
chore(lint): stabilize application presets

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -2,15 +2,23 @@ import { defineConfig } from "oxlint";
 import core from "ultracite/oxlint/core";
 import next from "ultracite/oxlint/next";
 import react from "ultracite/oxlint/react";
-// import vitest from "ultracite/oxlint/vitest";
+import vitest from "ultracite/oxlint/vitest";
 
 export default defineConfig({
-  extends: [
-    core,
-    react,
-    next,
-    // Deferred: 77 errors
-    // vitest,
+  extends: [core, react, next, vitest],
+  overrides: [
+    {
+      // The docs package intentionally runs these tests with Node's built-in test runner.
+      files: [
+        "apps/docs/src/lib/github.test.ts",
+        "apps/docs/src/lib/resolve-icon.test.ts",
+      ],
+      plugins: ["vitest"],
+      rules: {
+        "vitest/no-import-node-test": "off",
+        "vitest/prefer-importing-vitest-globals": "off",
+      },
+    },
   ],
   ignorePatterns: [
     ...(core.ignorePatterns ?? []),

--- a/packages/cli/src/commands/docker/helpers/compose-document.test.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-document.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import {
   addServices,
@@ -10,551 +10,553 @@ import type {
   ComposeMutationFailure,
 } from "./compose-document";
 
-test("reports a valid document without services as a structured no-services result", () => {
-  const result = getRemovableServiceNames({ name: "example" });
+describe("compose document", () => {
+  test("reports a valid document without services as a structured no-services result", () => {
+    const result = getRemovableServiceNames({ name: "example" });
 
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
+    expect(result.isErr()).toBeTruthy();
+    if (result.isOk()) {
+      return;
+    }
 
-  expect(result.error).toStrictEqual({ kind: "no-services" });
-});
-
-test("adds a service while preserving unrelated document data", () => {
-  const document: ComposeDocument = {
-    name: "example",
-    networks: {
-      internal: { driver: "bridge" },
-    },
-    services: {
-      app: {
-        image: "example/app",
-        labels: { "com.example.owner": "user" },
-      },
-    },
-    volumes: {
-      shared_data: { labels: { "com.example.owner": "user" } },
-    },
-  };
-
-  const result = addServices(document, [
-    {
-      config: {
-        image: "postgres:17",
-        volumes: ["postgres_data:/var/lib/postgresql/data"],
-      },
-      name: "postgres",
-    },
-  ]);
-
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
-
-  expect(result.value).toStrictEqual({
-    name: "example",
-    networks: {
-      internal: { driver: "bridge" },
-    },
-    services: {
-      app: {
-        image: "example/app",
-        labels: { "com.example.owner": "user" },
-      },
-      postgres: {
-        image: "postgres:17",
-        volumes: ["postgres_data:/var/lib/postgresql/data"],
-      },
-    },
-    volumes: {
-      postgres_data: {},
-      shared_data: { labels: { "com.example.owner": "user" } },
-    },
+    expect(result.error).toStrictEqual({ kind: "no-services" });
   });
-  expect(document).toStrictEqual({
-    name: "example",
-    networks: {
-      internal: { driver: "bridge" },
-    },
-    services: {
-      app: {
-        image: "example/app",
-        labels: { "com.example.owner": "user" },
+
+  test("adds a service while preserving unrelated document data", () => {
+    const document: ComposeDocument = {
+      name: "example",
+      networks: {
+        internal: { driver: "bridge" },
       },
-    },
-    volumes: {
-      shared_data: { labels: { "com.example.owner": "user" } },
-    },
+      services: {
+        app: {
+          image: "example/app",
+          labels: { "com.example.owner": "user" },
+        },
+      },
+      volumes: {
+        shared_data: { labels: { "com.example.owner": "user" } },
+      },
+    };
+
+    const result = addServices(document, [
+      {
+        config: {
+          image: "postgres:17",
+          volumes: ["postgres_data:/var/lib/postgresql/data"],
+        },
+        name: "postgres",
+      },
+    ]);
+
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value).toStrictEqual({
+      name: "example",
+      networks: {
+        internal: { driver: "bridge" },
+      },
+      services: {
+        app: {
+          image: "example/app",
+          labels: { "com.example.owner": "user" },
+        },
+        postgres: {
+          image: "postgres:17",
+          volumes: ["postgres_data:/var/lib/postgresql/data"],
+        },
+      },
+      volumes: {
+        postgres_data: {},
+        shared_data: { labels: { "com.example.owner": "user" } },
+      },
+    });
+    expect(document).toStrictEqual({
+      name: "example",
+      networks: {
+        internal: { driver: "bridge" },
+      },
+      services: {
+        app: {
+          image: "example/app",
+          labels: { "com.example.owner": "user" },
+        },
+      },
+      volumes: {
+        shared_data: { labels: { "com.example.owner": "user" } },
+      },
+    });
+    expect(result.value).not.toBe(document);
   });
-  expect(result.value).not.toBe(document);
-});
 
-test("rejects an existing service collision without a partial batch", () => {
-  const document: ComposeDocument = {
-    services: {
-      app: { image: "example/app" },
-    },
-  };
-  const original = structuredClone(document);
+  test("rejects an existing service collision without a partial batch", () => {
+    const document: ComposeDocument = {
+      services: {
+        app: { image: "example/app" },
+      },
+    };
+    const original = structuredClone(document);
 
-  const result = addServices(document, [
-    { config: { image: "example/worker" }, name: "worker" },
-    { config: { image: "replacement" }, name: "app" },
-  ]);
+    const result = addServices(document, [
+      { config: { image: "example/worker" }, name: "worker" },
+      { config: { image: "replacement" }, name: "app" },
+    ]);
 
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
+    expect(result.isErr()).toBeTruthy();
+    if (result.isOk()) {
+      return;
+    }
 
-  expect(result.error).toStrictEqual<ComposeMutationFailure>({
-    kind: "service-name-conflict",
-    scope: "existing-document",
-    serviceName: "app",
+    expect(result.error).toStrictEqual<ComposeMutationFailure>({
+      kind: "service-name-conflict",
+      scope: "existing-document",
+      serviceName: "app",
+    });
+    expect(document).toStrictEqual(original);
   });
-  expect(document).toStrictEqual(original);
-});
 
-test("rejects duplicate service names within one requested batch", () => {
-  const document: ComposeDocument = { services: {} };
+  test("rejects duplicate service names within one requested batch", () => {
+    const document: ComposeDocument = { services: {} };
 
-  const result = addServices(document, [
-    { config: { image: "example/worker" }, name: "worker" },
-    { config: { image: "example/other-worker" }, name: "worker" },
-  ]);
+    const result = addServices(document, [
+      { config: { image: "example/worker" }, name: "worker" },
+      { config: { image: "example/other-worker" }, name: "worker" },
+    ]);
 
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
+    expect(result.isErr()).toBeTruthy();
+    if (result.isOk()) {
+      return;
+    }
 
-  expect(result.error).toStrictEqual({
-    kind: "service-name-conflict",
-    scope: "requested-batch",
-    serviceName: "worker",
+    expect(result.error).toStrictEqual({
+      kind: "service-name-conflict",
+      scope: "requested-batch",
+      serviceName: "worker",
+    });
+    expect(document).toStrictEqual({ services: {} });
   });
-  expect(document).toStrictEqual({ services: {} });
-});
 
-test("treats an omitted service collection as empty", () => {
-  const document: ComposeDocument = {
-    name: "example",
-    networks: { internal: { driver: "bridge" } },
-  };
+  test("treats an omitted service collection as empty", () => {
+    const document: ComposeDocument = {
+      name: "example",
+      networks: { internal: { driver: "bridge" } },
+    };
 
-  const result = addServices(document, [
-    {
-      config: {
+    const result = addServices(document, [
+      {
+        config: {
+          image: "redis:7",
+          volumes: ["redis_data:/data"],
+        },
+        name: "redis",
+      },
+    ]);
+
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.services).toStrictEqual({
+      redis: {
         image: "redis:7",
         volumes: ["redis_data:/data"],
       },
-      name: "redis",
-    },
-  ]);
-
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
-
-  expect(result.value.services).toStrictEqual({
-    redis: {
-      image: "redis:7",
-      volumes: ["redis_data:/data"],
-    },
+    });
+    expect(result.value.volumes).toStrictEqual({ redis_data: {} });
+    expect(document).toStrictEqual({
+      name: "example",
+      networks: { internal: { driver: "bridge" } },
+    });
   });
-  expect(result.value.volumes).toStrictEqual({ redis_data: {} });
-  expect(document).toStrictEqual({
-    name: "example",
-    networks: { internal: { driver: "bridge" } },
-  });
-});
 
-test("preserves existing generated volume declarations", () => {
-  const document: ComposeDocument = {
-    services: {},
-    volumes: {
-      postgres_data: { external: true, labels: { owner: "user" } },
-    },
-  };
-
-  const result = addServices(document, [
-    {
-      config: {
-        image: "postgres:17",
-        volumes: ["postgres_data:/var/lib/postgresql/data"],
+  test("preserves existing generated volume declarations", () => {
+    const document: ComposeDocument = {
+      services: {},
+      volumes: {
+        postgres_data: { external: true, labels: { owner: "user" } },
       },
-      name: "postgres",
-    },
-  ]);
+    };
 
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
-
-  expect(result.value.volumes).toStrictEqual({
-    postgres_data: { external: true, labels: { owner: "user" } },
-  });
-  expect(document.volumes).toStrictEqual({
-    postgres_data: { external: true, labels: { owner: "user" } },
-  });
-});
-
-test("does not create generated volumes for bind or anonymous mounts", () => {
-  const document: ComposeDocument = { services: {} };
-
-  const result = addServices(document, [
-    {
-      config: {
-        image: "example/app",
-        volumes: [
-          "./data:/data",
-          "/tmp/cache:/cache",
-          "C:/workspace:/workspace",
-          "C:\\workspace:/workspace",
-          "/anonymous",
-        ],
-      },
-      name: "app",
-    },
-  ]);
-
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
-
-  expect(result.value.volumes).toBeUndefined();
-});
-
-test("removes a service and its unreferenced generated volume", () => {
-  const document: ComposeDocument = {
-    name: "example",
-    networks: {
-      internal: { driver: "bridge" },
-    },
-    services: {
-      app: {
-        image: "example/app",
-      },
-      postgres: {
-        image: "postgres:17",
-        volumes: ["postgres_data:/var/lib/postgresql/data"],
-      },
-    },
-    volumes: {
-      postgres_data: {},
-      shared_data: { labels: { owner: "user" } },
-    },
-  };
-  const original = structuredClone(document);
-
-  const result = removeServices(document, ["postgres"]);
-
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
-
-  expect(result.value).toStrictEqual({
-    name: "example",
-    networks: {
-      internal: { driver: "bridge" },
-    },
-    services: {
-      app: {
-        image: "example/app",
-      },
-    },
-    volumes: {
-      shared_data: { labels: { owner: "user" } },
-    },
-  });
-  expect(document).toStrictEqual(original);
-  expect(result.value).not.toBe(document);
-});
-
-test("omits the volume collection when its last generated declaration is removed", () => {
-  const document: ComposeDocument = {
-    services: {
-      postgres: {
-        image: "postgres:17",
-        volumes: ["postgres_data:/var/lib/postgresql/data"],
-      },
-    },
-    volumes: {
-      postgres_data: {},
-    },
-  };
-
-  const result = removeServices(document, ["postgres"]);
-
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
-
-  expect(result.value).toStrictEqual({ services: {} });
-  expect(result.value).not.toHaveProperty("volumes");
-});
-
-test("rejects a removal batch with a missing service without changing the document", () => {
-  const document: ComposeDocument = {
-    services: {
-      postgres: { image: "postgres:17" },
-      redis: { image: "redis:7" },
-    },
-  };
-  const original = structuredClone(document);
-
-  const result = removeServices(document, ["postgres", "missing"]);
-
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
-
-  expect(result.error).toStrictEqual<ComposeMutationFailure>({
-    kind: "service-not-found",
-    serviceName: "missing",
-  });
-  expect(document).toStrictEqual(original);
-});
-
-test("rejects an empty removal batch", () => {
-  const document: ComposeDocument = {
-    services: { postgres: { image: "postgres:17" } },
-  };
-
-  const result = removeServices(document, []);
-
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
-
-  expect(result.error).toStrictEqual({ kind: "empty-service-batch" });
-  expect(document.services).toHaveProperty("postgres");
-});
-
-test("rejects an empty service name in a removal batch", () => {
-  const document: ComposeDocument = {
-    services: { postgres: { image: "postgres:17" } },
-  };
-
-  const result = removeServices(document, [""]);
-
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
-
-  expect(result.error).toStrictEqual<ComposeMutationFailure>({
-    index: 0,
-    kind: "invalid-service-entry",
-    reason: "empty-name",
-    serviceName: "",
-  });
-});
-
-test("rejects removal when a remaining service depends on a selected service", () => {
-  const document: ComposeDocument = {
-    services: {
-      app: {
-        depends_on: ["postgres"],
-        image: "example/app",
-      },
-      postgres: { image: "postgres:17" },
-      redis: { image: "redis:7" },
-    },
-  };
-
-  const result = removeServices(document, ["postgres", "redis"]);
-
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
-
-  expect(result.error).toStrictEqual<ComposeMutationFailure>({
-    dependencyName: "postgres",
-    kind: "service-dependency-conflict",
-    serviceName: "app",
-  });
-  expect(document.services).toHaveProperty("postgres");
-  expect(document.services).toHaveProperty("redis");
-});
-
-test("protects dependencies declared in the mapping form", () => {
-  const document: ComposeDocument = {
-    services: {
-      app: {
-        depends_on: {
-          postgres: { condition: "service_healthy" },
+    const result = addServices(document, [
+      {
+        config: {
+          image: "postgres:17",
+          volumes: ["postgres_data:/var/lib/postgresql/data"],
         },
-        image: "example/app",
+        name: "postgres",
       },
-      postgres: { image: "postgres:17" },
-    },
-  };
+    ]);
 
-  const result = removeServices(document, ["postgres"]);
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
 
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
-
-  expect(result.error).toStrictEqual({
-    dependencyName: "postgres",
-    kind: "service-dependency-conflict",
-    serviceName: "app",
+    expect(result.value.volumes).toStrictEqual({
+      postgres_data: { external: true, labels: { owner: "user" } },
+    });
+    expect(document.volumes).toStrictEqual({
+      postgres_data: { external: true, labels: { owner: "user" } },
+    });
   });
-});
 
-test("ignores service references outside explicit depends_on declarations", () => {
-  const document: ComposeDocument = {
-    services: {
+  test("does not create generated volumes for bind or anonymous mounts", () => {
+    const document: ComposeDocument = { services: {} };
+
+    const result = addServices(document, [
+      {
+        config: {
+          image: "example/app",
+          volumes: [
+            "./data:/data",
+            "/tmp/cache:/cache",
+            "C:/workspace:/workspace",
+            "C:\\workspace:/workspace",
+            "/anonymous",
+          ],
+        },
+        name: "app",
+      },
+    ]);
+
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.volumes).toBeUndefined();
+  });
+
+  test("removes a service and its unreferenced generated volume", () => {
+    const document: ComposeDocument = {
+      name: "example",
+      networks: {
+        internal: { driver: "bridge" },
+      },
+      services: {
+        app: {
+          image: "example/app",
+        },
+        postgres: {
+          image: "postgres:17",
+          volumes: ["postgres_data:/var/lib/postgresql/data"],
+        },
+      },
+      volumes: {
+        postgres_data: {},
+        shared_data: { labels: { owner: "user" } },
+      },
+    };
+    const original = structuredClone(document);
+
+    const result = removeServices(document, ["postgres"]);
+
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value).toStrictEqual({
+      name: "example",
+      networks: {
+        internal: { driver: "bridge" },
+      },
+      services: {
+        app: {
+          image: "example/app",
+        },
+      },
+      volumes: {
+        shared_data: { labels: { owner: "user" } },
+      },
+    });
+    expect(document).toStrictEqual(original);
+    expect(result.value).not.toBe(document);
+  });
+
+  test("omits the volume collection when its last generated declaration is removed", () => {
+    const document: ComposeDocument = {
+      services: {
+        postgres: {
+          image: "postgres:17",
+          volumes: ["postgres_data:/var/lib/postgresql/data"],
+        },
+      },
+      volumes: {
+        postgres_data: {},
+      },
+    };
+
+    const result = removeServices(document, ["postgres"]);
+
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value).toStrictEqual({ services: {} });
+    expect(result.value).not.toHaveProperty("volumes");
+  });
+
+  test("rejects a removal batch with a missing service without changing the document", () => {
+    const document: ComposeDocument = {
+      services: {
+        postgres: { image: "postgres:17" },
+        redis: { image: "redis:7" },
+      },
+    };
+    const original = structuredClone(document);
+
+    const result = removeServices(document, ["postgres", "missing"]);
+
+    expect(result.isErr()).toBeTruthy();
+    if (result.isOk()) {
+      return;
+    }
+
+    expect(result.error).toStrictEqual<ComposeMutationFailure>({
+      kind: "service-not-found",
+      serviceName: "missing",
+    });
+    expect(document).toStrictEqual(original);
+  });
+
+  test("rejects an empty removal batch", () => {
+    const document: ComposeDocument = {
+      services: { postgres: { image: "postgres:17" } },
+    };
+
+    const result = removeServices(document, []);
+
+    expect(result.isErr()).toBeTruthy();
+    if (result.isOk()) {
+      return;
+    }
+
+    expect(result.error).toStrictEqual({ kind: "empty-service-batch" });
+    expect(document.services).toHaveProperty("postgres");
+  });
+
+  test("rejects an empty service name in a removal batch", () => {
+    const document: ComposeDocument = {
+      services: { postgres: { image: "postgres:17" } },
+    };
+
+    const result = removeServices(document, [""]);
+
+    expect(result.isErr()).toBeTruthy();
+    if (result.isOk()) {
+      return;
+    }
+
+    expect(result.error).toStrictEqual<ComposeMutationFailure>({
+      index: 0,
+      kind: "invalid-service-entry",
+      reason: "empty-name",
+      serviceName: "",
+    });
+  });
+
+  test("rejects removal when a remaining service depends on a selected service", () => {
+    const document: ComposeDocument = {
+      services: {
+        app: {
+          depends_on: ["postgres"],
+          image: "example/app",
+        },
+        postgres: { image: "postgres:17" },
+        redis: { image: "redis:7" },
+      },
+    };
+
+    const result = removeServices(document, ["postgres", "redis"]);
+
+    expect(result.isErr()).toBeTruthy();
+    if (result.isOk()) {
+      return;
+    }
+
+    expect(result.error).toStrictEqual<ComposeMutationFailure>({
+      dependencyName: "postgres",
+      kind: "service-dependency-conflict",
+      serviceName: "app",
+    });
+    expect(document.services).toHaveProperty("postgres");
+    expect(document.services).toHaveProperty("redis");
+  });
+
+  test("protects dependencies declared in the mapping form", () => {
+    const document: ComposeDocument = {
+      services: {
+        app: {
+          depends_on: {
+            postgres: { condition: "service_healthy" },
+          },
+          image: "example/app",
+        },
+        postgres: { image: "postgres:17" },
+      },
+    };
+
+    const result = removeServices(document, ["postgres"]);
+
+    expect(result.isErr()).toBeTruthy();
+    if (result.isOk()) {
+      return;
+    }
+
+    expect(result.error).toStrictEqual({
+      dependencyName: "postgres",
+      kind: "service-dependency-conflict",
+      serviceName: "app",
+    });
+  });
+
+  test("ignores service references outside explicit depends_on declarations", () => {
+    const document: ComposeDocument = {
+      services: {
+        app: {
+          environment: ["DATABASE_HOST=postgres"],
+          image: "example/app",
+          links: ["postgres"],
+          network_mode: "service:postgres",
+        },
+        postgres: { image: "postgres:17" },
+      },
+    };
+
+    const result = removeServices(document, ["postgres"]);
+
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.services).toStrictEqual({
       app: {
         environment: ["DATABASE_HOST=postgres"],
         image: "example/app",
         links: ["postgres"],
         network_mode: "service:postgres",
       },
-      postgres: { image: "postgres:17" },
-    },
-  };
-
-  const result = removeServices(document, ["postgres"]);
-
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
-
-  expect(result.value.services).toStrictEqual({
-    app: {
-      environment: ["DATABASE_HOST=postgres"],
-      image: "example/app",
-      links: ["postgres"],
-      network_mode: "service:postgres",
-    },
+    });
   });
-});
 
-test("preserves a generated volume shared by a remaining service", () => {
-  const document: ComposeDocument = {
-    services: {
-      backup: {
-        image: "example/backup",
-        volumes: ["postgres_data:/backup"],
+  test("preserves a generated volume shared by a remaining service", () => {
+    const document: ComposeDocument = {
+      services: {
+        backup: {
+          image: "example/backup",
+          volumes: ["postgres_data:/backup"],
+        },
+        postgres: {
+          image: "postgres:17",
+          volumes: ["postgres_data:/var/lib/postgresql/data"],
+        },
       },
-      postgres: {
-        image: "postgres:17",
-        volumes: ["postgres_data:/var/lib/postgresql/data"],
+      volumes: {
+        postgres_data: {},
       },
-    },
-    volumes: {
-      postgres_data: {},
-    },
-  };
+    };
 
-  const result = removeServices(document, ["postgres"]);
+    const result = removeServices(document, ["postgres"]);
 
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
 
-  expect(result.value.volumes).toStrictEqual({ postgres_data: {} });
-});
+    expect(result.value.volumes).toStrictEqual({ postgres_data: {} });
+  });
 
-test("cleans only simple generated volume declarations", () => {
-  const document: ComposeDocument = {
-    services: {
-      mysql: {
-        image: "mysql:9",
-        volumes: ["mysql_data:/var/lib/mysql"],
+  test("cleans only simple generated volume declarations", () => {
+    const document: ComposeDocument = {
+      services: {
+        mysql: {
+          image: "mysql:9",
+          volumes: ["mysql_data:/var/lib/mysql"],
+        },
+        postgres: {
+          image: "postgres:17",
+          volumes: [
+            "postgres_data:/var/lib/postgresql/data",
+            "shared_data:/shared",
+            "./host-data:/bind",
+            "/anonymous",
+            "custom_data:/custom",
+          ],
+        },
+        redis: {
+          image: "redis:7",
+          volumes: [{ source: "redis_data", target: "/data", type: "volume" }],
+        },
       },
-      postgres: {
-        image: "postgres:17",
-        volumes: [
-          "postgres_data:/var/lib/postgresql/data",
-          "shared_data:/shared",
-          "./host-data:/bind",
-          "/anonymous",
-          "custom_data:/custom",
-        ],
+      volumes: {
+        custom_data: {},
+        mysql_data: { labels: { owner: "user" } },
+        postgres_data: {},
+        redis_data: { external: true },
+        shared_data: {},
       },
-      redis: {
-        image: "redis:7",
-        volumes: [{ source: "redis_data", target: "/data", type: "volume" }],
-      },
-    },
-    volumes: {
+    };
+
+    const result = removeServices(document, ["postgres", "redis", "mysql"]);
+
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.volumes).toStrictEqual({
       custom_data: {},
       mysql_data: { labels: { owner: "user" } },
-      postgres_data: {},
       redis_data: { external: true },
       shared_data: {},
-    },
-  };
-
-  const result = removeServices(document, ["postgres", "redis", "mysql"]);
-
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
-
-  expect(result.value.volumes).toStrictEqual({
-    custom_data: {},
-    mysql_data: { labels: { owner: "user" } },
-    redis_data: { external: true },
-    shared_data: {},
+    });
   });
-});
 
-test("preserves top-level volumes for bind and anonymous mounts", () => {
-  const document: ComposeDocument = {
-    services: {
-      app: {
-        image: "example/app",
-        volumes: ["./app-data:/data", "/cache"],
+  test("preserves top-level volumes for bind and anonymous mounts", () => {
+    const document: ComposeDocument = {
+      services: {
+        app: {
+          image: "example/app",
+          volumes: ["./app-data:/data", "/cache"],
+        },
       },
-    },
-    volumes: {
-      app_data: {},
-    },
-  };
+      volumes: {
+        app_data: {},
+      },
+    };
 
-  const result = removeServices(document, ["app"]);
+    const result = removeServices(document, ["app"]);
 
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
 
-  expect(result.value.volumes).toStrictEqual({ app_data: {} });
-});
+    expect(result.value.volumes).toStrictEqual({ app_data: {} });
+  });
 
-test("preserves an empty volume collection when no generated declaration is removed", () => {
-  const document: ComposeDocument = {
-    services: {
-      app: { image: "example/app" },
-    },
-    volumes: {},
-  };
+  test("preserves an empty volume collection when no generated declaration is removed", () => {
+    const document: ComposeDocument = {
+      services: {
+        app: { image: "example/app" },
+      },
+      volumes: {},
+    };
 
-  const result = removeServices(document, ["app"]);
+    const result = removeServices(document, ["app"]);
 
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
 
-  expect(result.value.volumes).toStrictEqual({});
+    expect(result.value.volumes).toStrictEqual({});
+  });
 });

--- a/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
+++ b/packages/cli/src/commands/docker/helpers/compose-file-adapter.test.ts
@@ -15,7 +15,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import {
   COMPOSE_FILE_NAMES,
@@ -75,132 +75,168 @@ async function readComposeFailure(source: string): Promise<{
   }
 }
 
-test("discovers every supported Compose candidate without selecting one", async () => {
-  const cwd = await createTempDirectory();
+describe("Compose file adapter", () => {
+  test("discovers every supported Compose candidate without selecting one", async () => {
+    const cwd = await createTempDirectory();
 
-  try {
-    await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
-    await writeFile(path.join(cwd, "docker-compose.yml"), "services: {}\n");
+    try {
+      await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
+      await writeFile(path.join(cwd, "docker-compose.yml"), "services: {}\n");
 
-    const result = await discoverComposeFiles(cwd);
+      const result = await discoverComposeFiles(cwd);
 
-    expect(result.isOk()).toBeTruthy();
-    if (result.isErr()) {
-      return;
-    }
-
-    expect(result.value).toStrictEqual(["compose.yaml", "docker-compose.yml"]);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
-
-test("inspects supported Compose candidates concurrently", async () => {
-  const started: string[] = [];
-  const { promise: firstStat, resolve: releaseFirstStat } =
-    Promise.withResolvers<true>();
-
-  const resultPromise = discoverComposeFiles("/project", {
-    readFile: vi.fn().mockResolvedValue(""),
-    stat: vi.fn(async (filePath: string) => {
-      const fileName = path.basename(filePath);
-      started.push(fileName);
-      if (started.length === 1) {
-        await firstStat;
+      expect(result.isOk()).toBeTruthy();
+      if (result.isErr()) {
+        return;
       }
 
-      return {
-        isFile: () =>
-          fileName === "compose.yaml" || fileName === "docker-compose.yaml",
-      };
-    }),
+      expect(result.value).toStrictEqual([
+        "compose.yaml",
+        "docker-compose.yml",
+      ]);
+    } finally {
+      await removeTempDirectory(cwd);
+    }
   });
 
-  expect(started).toStrictEqual([...COMPOSE_FILE_NAMES]);
+  test("inspects supported Compose candidates concurrently", async () => {
+    const started: string[] = [];
+    const { promise: firstStat, resolve: releaseFirstStat } =
+      Promise.withResolvers<true>();
 
-  releaseFirstStat(true);
-  const result = await resultPromise;
-  expect(result.isOk()).toBeTruthy();
-  if (result.isErr()) {
-    return;
-  }
+    const resultPromise = discoverComposeFiles("/project", {
+      readFile: vi.fn<() => Promise<string>>().mockResolvedValue(""),
+      stat: vi.fn<(filePath: string) => Promise<{ isFile: () => boolean }>>(
+        async (filePath: string) => {
+          const fileName = path.basename(filePath);
+          started.push(fileName);
+          if (started.length === 1) {
+            await firstStat;
+          }
 
-  expect(result.value).toStrictEqual(["compose.yaml", "docker-compose.yaml"]);
-});
+          return {
+            isFile: () =>
+              fileName === "compose.yaml" || fileName === "docker-compose.yaml",
+          };
+        }
+      ),
+    });
 
-test("reports no candidates without inventing a Compose filename", async () => {
-  const cwd = await createTempDirectory();
+    expect(started).toStrictEqual([...COMPOSE_FILE_NAMES]);
 
-  try {
-    const result = await discoverComposeFiles(cwd);
-
+    releaseFirstStat(true);
+    const result = await resultPromise;
     expect(result.isOk()).toBeTruthy();
     if (result.isErr()) {
       return;
     }
 
-    expect(result.value).toStrictEqual([]);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
+    expect(result.value).toStrictEqual(["compose.yaml", "docker-compose.yaml"]);
+  });
 
-test("recognizes only the supported Compose filenames", async () => {
-  const cwd = await createTempDirectory();
+  test("reports no candidates without inventing a Compose filename", async () => {
+    const cwd = await createTempDirectory();
 
-  try {
-    await writeFile(path.join(cwd, "compose.json"), "{}\n");
-    await writeFile(path.join(cwd, "custom-compose.yaml"), "services: {}\n");
+    try {
+      const result = await discoverComposeFiles(cwd);
 
-    const result = await discoverComposeFiles(cwd);
+      expect(result.isOk()).toBeTruthy();
+      if (result.isErr()) {
+        return;
+      }
 
-    expect(result.isOk()).toBeTruthy();
-    if (result.isErr()) {
-      return;
+      expect(result.value).toStrictEqual([]);
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    expect(result.value).toStrictEqual([]);
-    expect(COMPOSE_FILE_NAMES).toStrictEqual([
-      "compose.yaml",
-      "compose.yml",
-      "docker-compose.yaml",
-      "docker-compose.yml",
-    ]);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
+  test("recognizes only the supported Compose filenames", async () => {
+    const cwd = await createTempDirectory();
 
-test("does not treat a directory with a supported name as a Compose candidate", async () => {
-  const cwd = await createTempDirectory();
+    try {
+      await writeFile(path.join(cwd, "compose.json"), "{}\n");
+      await writeFile(path.join(cwd, "custom-compose.yaml"), "services: {}\n");
 
-  try {
-    await mkdir(path.join(cwd, "compose.yaml"));
+      const result = await discoverComposeFiles(cwd);
 
-    const result = await discoverComposeFiles(cwd);
+      expect(result.isOk()).toBeTruthy();
+      if (result.isErr()) {
+        return;
+      }
 
-    expect(result.isOk()).toBeTruthy();
-    if (result.isErr()) {
-      return;
+      expect(result.value).toStrictEqual([]);
+      expect(COMPOSE_FILE_NAMES).toStrictEqual([
+        "compose.yaml",
+        "compose.yml",
+        "docker-compose.yaml",
+        "docker-compose.yml",
+      ]);
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    expect(result.value).toStrictEqual([]);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
+  test("does not treat a directory with a supported name as a Compose candidate", async () => {
+    const cwd = await createTempDirectory();
 
-test("reports a recognized symlink during Compose discovery", async () => {
-  const cwd = await createTempDirectory();
+    try {
+      await mkdir(path.join(cwd, "compose.yaml"));
 
-  try {
-    await writeFile(path.join(cwd, "user-compose.yaml"), "services: {}\n");
-    await symlink(
-      path.join(cwd, "user-compose.yaml"),
-      path.join(cwd, "compose.yaml")
-    );
+      const result = await discoverComposeFiles(cwd);
 
-    const result = await discoverComposeFiles(cwd);
+      expect(result.isOk()).toBeTruthy();
+      if (result.isErr()) {
+        return;
+      }
+
+      expect(result.value).toStrictEqual([]);
+    } finally {
+      await removeTempDirectory(cwd);
+    }
+  });
+
+  test("reports a recognized symlink during Compose discovery", async () => {
+    const cwd = await createTempDirectory();
+
+    try {
+      await writeFile(path.join(cwd, "user-compose.yaml"), "services: {}\n");
+      await symlink(
+        path.join(cwd, "user-compose.yaml"),
+        path.join(cwd, "compose.yaml")
+      );
+
+      const result = await discoverComposeFiles(cwd);
+
+      expect(result.isErr()).toBeTruthy();
+      if (result.isOk()) {
+        return;
+      }
+
+      expect(result.error).toStrictEqual({
+        fileName: "compose.yaml",
+        kind: "symlinked-document",
+      });
+    } finally {
+      await removeTempDirectory(cwd);
+    }
+  });
+
+  test("reports an inspection failure instead of treating an inaccessible candidate as absent", async () => {
+    const inaccessible = Object.assign(new Error("permission denied"), {
+      code: "EACCES",
+    });
+
+    const result = await discoverComposeFiles("/project", {
+      // Preserve the async file-system adapter contract in this test double.
+      // oxlint-disable-next-line require-await
+      readFile: async () => "",
+      // Preserve the async file-system adapter contract in this test double.
+      // oxlint-disable-next-line require-await
+      stat: async () => {
+        throw inaccessible;
+      },
+    });
 
     expect(result.isErr()).toBeTruthy();
     if (result.isOk()) {
@@ -209,43 +245,13 @@ test("reports a recognized symlink during Compose discovery", async () => {
 
     expect(result.error).toStrictEqual({
       fileName: "compose.yaml",
-      kind: "symlinked-document",
+      kind: "discovery-failure",
     });
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
-
-test("reports an inspection failure instead of treating an inaccessible candidate as absent", async () => {
-  const inaccessible = Object.assign(new Error("permission denied"), {
-    code: "EACCES",
   });
 
-  const result = await discoverComposeFiles("/project", {
-    // Preserve the async file-system adapter contract in this test double.
-    // oxlint-disable-next-line require-await
-    readFile: async () => "",
-    // Preserve the async file-system adapter contract in this test double.
-    // oxlint-disable-next-line require-await
-    stat: async () => {
-      throw inaccessible;
-    },
-  });
-
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
-
-  expect(result.error).toStrictEqual({
-    fileName: "compose.yaml",
-    kind: "discovery-failure",
-  });
-});
-
-test("reads a valid single-document Compose document and preserves open-world data", async () => {
-  const cwd = await createTempDirectory();
-  const source = `name: example
+  test("reads a valid single-document Compose document and preserves open-world data", async () => {
+    const cwd = await createTempDirectory();
+    const source = `name: example
 x-user-extension:
   enabled: true
 services:
@@ -259,287 +265,186 @@ volumes:
       com.example.owner: user
 `;
 
-  try {
-    await writeFile(path.join(cwd, "compose.yaml"), source);
+    try {
+      await writeFile(path.join(cwd, "compose.yaml"), source);
 
-    const result = await readComposeDocument(cwd, "compose.yaml");
+      const result = await readComposeDocument(cwd, "compose.yaml");
 
-    expect(result.isOk()).toBeTruthy();
-    if (result.isErr()) {
-      return;
-    }
+      expect(result.isOk()).toBeTruthy();
+      if (result.isErr()) {
+        return;
+      }
 
-    expect(result.value.document).toStrictEqual({
-      name: "example",
-      services: {
-        app: {
-          image: "example/app",
-          labels: { "com.example.owner": "user" },
+      expect(result.value.document).toStrictEqual({
+        name: "example",
+        services: {
+          app: {
+            image: "example/app",
+            labels: { "com.example.owner": "user" },
+          },
         },
-      },
-      volumes: {
-        app_data: {
-          labels: { "com.example.owner": "user" },
+        volumes: {
+          app_data: {
+            labels: { "com.example.owner": "user" },
+          },
         },
-      },
-      "x-user-extension": { enabled: true },
-    });
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
-
-test("allows a Compose document to omit services for initialization", async () => {
-  const cwd = await createTempDirectory();
-
-  try {
-    await writeFile(
-      path.join(cwd, "compose.yaml"),
-      "name: example\nnetworks:\n  internal:\n    driver: bridge\n"
-    );
-
-    const result = await readComposeDocument(cwd, "compose.yaml");
-
-    expect(result.isOk()).toBeTruthy();
-    if (result.isErr()) {
-      return;
+        "x-user-extension": { enabled: true },
+      });
+    } finally {
+      await removeTempDirectory(cwd);
     }
-
-    expect(result.value.document).toStrictEqual({
-      name: "example",
-      networks: { internal: { driver: "bridge" } },
-    });
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
-
-test("rejects invalid YAML without changing the original file", async () => {
-  const result = await readComposeFailure("services:\n  app: [\n");
-
-  expect(result.error).toStrictEqual({
-    fileName: "compose.yaml",
-    kind: "parse-failure",
-    reason: "invalid-yaml",
   });
-  expect(result.contents).toBe("services:\n  app: [\n");
-});
 
-test("rejects multi-document YAML without changing the original file", async () => {
-  const result = await readComposeFailure("services: {}\n---\nservices: {}\n");
+  test("allows a Compose document to omit services for initialization", async () => {
+    const cwd = await createTempDirectory();
 
-  expect(result.error).toStrictEqual({
-    fileName: "compose.yaml",
-    kind: "parse-failure",
-    reason: "multi-document",
-  });
-  expect(result.contents).toBe("services: {}\n---\nservices: {}\n");
-});
+    try {
+      await writeFile(
+        path.join(cwd, "compose.yaml"),
+        "name: example\nnetworks:\n  internal:\n    driver: bridge\n"
+      );
 
-test("rejects duplicate YAML mapping keys without changing the original file", async () => {
-  const result = await readComposeFailure("services: {}\nservices: {}\n");
+      const result = await readComposeDocument(cwd, "compose.yaml");
 
-  expect(result.error).toStrictEqual({
-    fileName: "compose.yaml",
-    kind: "parse-failure",
-    reason: "duplicate-key",
-  });
-  expect(result.contents).toBe("services: {}\nservices: {}\n");
-});
+      expect(result.isOk()).toBeTruthy();
+      if (result.isErr()) {
+        return;
+      }
 
-test("rejects an empty YAML stream without changing the original file", async () => {
-  const result = await readComposeFailure("");
-
-  expect(result.error).toStrictEqual({
-    fileName: "compose.yaml",
-    kind: "parse-failure",
-    reason: "empty-document",
-  });
-  expect(result.contents).toBe("");
-});
-
-test("rejects a non-mapping Compose root without changing the original file", async () => {
-  const result = await readComposeFailure("- not-a-compose-document\n");
-
-  expect(result.error).toStrictEqual({
-    field: "root",
-    fileName: "compose.yaml",
-    kind: "invalid-document",
-  });
-  expect(result.contents).toBe("- not-a-compose-document\n");
-});
-
-test("rejects an invalid services collection without changing the original file", async () => {
-  const result = await readComposeFailure("services: []\n");
-
-  expect(result.error).toStrictEqual({
-    field: "services",
-    fileName: "compose.yaml",
-    kind: "invalid-document",
-  });
-  expect(result.contents).toBe("services: []\n");
-});
-
-test("rejects an invalid service entry without changing the original file", async () => {
-  const result = await readComposeFailure("services:\n  app: []\n");
-
-  expect(result.error).toStrictEqual({
-    field: "services",
-    fileName: "compose.yaml",
-    kind: "invalid-document",
-    serviceName: "app",
-  });
-  expect(result.contents).toBe("services:\n  app: []\n");
-});
-
-test("rejects an invalid volumes collection without changing the original file", async () => {
-  const result = await readComposeFailure("services: {}\nvolumes: []\n");
-
-  expect(result.error).toStrictEqual({
-    field: "volumes",
-    fileName: "compose.yaml",
-    kind: "invalid-document",
-  });
-  expect(result.contents).toBe("services: {}\nvolumes: []\n");
-});
-
-test("reports a missing selected Compose document as a structured failure", async () => {
-  const cwd = await createTempDirectory();
-
-  try {
-    const result = await readComposeDocument(cwd, "compose.yaml");
-
-    expect(result.isErr()).toBeTruthy();
-    if (result.isOk()) {
-      return;
+      expect(result.value.document).toStrictEqual({
+        name: "example",
+        networks: { internal: { driver: "bridge" } },
+      });
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
+
+  test("rejects invalid YAML without changing the original file", async () => {
+    const result = await readComposeFailure("services:\n  app: [\n");
 
     expect(result.error).toStrictEqual({
       fileName: "compose.yaml",
-      kind: "missing-document",
+      kind: "parse-failure",
+      reason: "invalid-yaml",
     });
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
-
-test("reports a non-missing read failure as structured data", async () => {
-  const unreadable = Object.assign(new Error("permission denied"), {
-    code: "EACCES",
+    expect(result.contents).toBe("services:\n  app: [\n");
   });
 
-  const result = await readComposeDocument("/project", "compose.yaml", {
-    // Preserve the async file-system adapter contract in this test double.
-    // oxlint-disable-next-line require-await
-    readFile: async () => {
-      throw unreadable;
-    },
-    // Preserve the async file-system adapter contract in this test double.
-    // oxlint-disable-next-line require-await
-    stat: async () => ({ isFile: () => true }),
-  });
-
-  expect(result.isErr()).toBeTruthy();
-  if (result.isOk()) {
-    return;
-  }
-
-  expect(result.error).toStrictEqual({
-    fileName: "compose.yaml",
-    kind: "read-failure",
-  });
-});
-
-test("replaces an existing Compose document through the write seam", async () => {
-  const cwd = await createTempDirectory();
-  const composePath = path.join(cwd, "compose.yaml");
-
-  try {
-    await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
-
-    const readResult = await readComposeDocument(cwd, "compose.yaml");
-    expect(readResult.isOk()).toBeTruthy();
-    if (readResult.isErr()) {
-      return;
-    }
-
-    const writeResult = await writeComposeDocument(
-      cwd,
-      "compose.yaml",
-      { services: { app: { image: "new/app" } } },
-      readResult.value.revision
+  test("rejects multi-document YAML without changing the original file", async () => {
+    const result = await readComposeFailure(
+      "services: {}\n---\nservices: {}\n"
     );
 
-    expect(writeResult.isOk()).toBeTruthy();
-    expect(await readFile(composePath, "utf-8")).toContain("image: new/app");
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
+    expect(result.error).toStrictEqual({
+      fileName: "compose.yaml",
+      kind: "parse-failure",
+      reason: "multi-document",
+    });
+    expect(result.contents).toBe("services: {}\n---\nservices: {}\n");
+  });
 
-test("preserves an existing Compose file's permission mode bits", async () => {
-  const cwd = await createTempDirectory();
-  const composePath = path.join(cwd, "compose.yaml");
+  test("rejects duplicate YAML mapping keys without changing the original file", async () => {
+    const result = await readComposeFailure("services: {}\nservices: {}\n");
 
-  try {
-    await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
-    await chmod(composePath, 0o640);
+    expect(result.error).toStrictEqual({
+      fileName: "compose.yaml",
+      kind: "parse-failure",
+      reason: "duplicate-key",
+    });
+    expect(result.contents).toBe("services: {}\nservices: {}\n");
+  });
 
-    const readResult = await readComposeDocument(cwd, "compose.yaml");
-    expect(readResult.isOk()).toBeTruthy();
-    if (readResult.isErr()) {
-      return;
+  test("rejects an empty YAML stream without changing the original file", async () => {
+    const result = await readComposeFailure("");
+
+    expect(result.error).toStrictEqual({
+      fileName: "compose.yaml",
+      kind: "parse-failure",
+      reason: "empty-document",
+    });
+    expect(result.contents).toBe("");
+  });
+
+  test("rejects a non-mapping Compose root without changing the original file", async () => {
+    const result = await readComposeFailure("- not-a-compose-document\n");
+
+    expect(result.error).toStrictEqual({
+      field: "root",
+      fileName: "compose.yaml",
+      kind: "invalid-document",
+    });
+    expect(result.contents).toBe("- not-a-compose-document\n");
+  });
+
+  test("rejects an invalid services collection without changing the original file", async () => {
+    const result = await readComposeFailure("services: []\n");
+
+    expect(result.error).toStrictEqual({
+      field: "services",
+      fileName: "compose.yaml",
+      kind: "invalid-document",
+    });
+    expect(result.contents).toBe("services: []\n");
+  });
+
+  test("rejects an invalid service entry without changing the original file", async () => {
+    const result = await readComposeFailure("services:\n  app: []\n");
+
+    expect(result.error).toStrictEqual({
+      field: "services",
+      fileName: "compose.yaml",
+      kind: "invalid-document",
+      serviceName: "app",
+    });
+    expect(result.contents).toBe("services:\n  app: []\n");
+  });
+
+  test("rejects an invalid volumes collection without changing the original file", async () => {
+    const result = await readComposeFailure("services: {}\nvolumes: []\n");
+
+    expect(result.error).toStrictEqual({
+      field: "volumes",
+      fileName: "compose.yaml",
+      kind: "invalid-document",
+    });
+    expect(result.contents).toBe("services: {}\nvolumes: []\n");
+  });
+
+  test("reports a missing selected Compose document as a structured failure", async () => {
+    const cwd = await createTempDirectory();
+
+    try {
+      const result = await readComposeDocument(cwd, "compose.yaml");
+
+      expect(result.isErr()).toBeTruthy();
+      if (result.isOk()) {
+        return;
+      }
+
+      expect(result.error).toStrictEqual({
+        fileName: "compose.yaml",
+        kind: "missing-document",
+      });
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    const writeResult = await writeComposeDocument(
-      cwd,
-      "compose.yaml",
-      { services: { app: { image: "new/app" } } },
-      readResult.value.revision
-    );
-
-    expect(writeResult.isOk()).toBeTruthy();
-    const composeStats = await lstat(composePath);
-    expect(composeStats.mode % 0o1_0000).toBe(0o640);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
-
-test("uses normal filesystem defaults when creating a new Compose file", async () => {
-  const cwd = await createTempDirectory();
-  const composePath = path.join(cwd, "compose.yaml");
-  const expectedPath = path.join(cwd, "expected-mode.txt");
-
-  try {
-    await writeFile(expectedPath, "");
-    const expectedStats = await lstat(expectedPath);
-    const expectedMode = expectedStats.mode % 0o1000;
-
-    const result = await writeComposeDocument(cwd, "compose.yaml", {
-      services: {},
+  test("reports a non-missing read failure as structured data", async () => {
+    const unreadable = Object.assign(new Error("permission denied"), {
+      code: "EACCES",
     });
 
-    expect(result.isOk()).toBeTruthy();
-    const composeStats = await lstat(composePath);
-    expect(composeStats.mode % 0o1000).toBe(expectedMode);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
-
-test("rejects a symlinked Compose path without replacing the link", async () => {
-  const cwd = await createTempDirectory();
-  const targetPath = path.join(cwd, "user-compose.yaml");
-  const composePath = path.join(cwd, "compose.yaml");
-  const source = "services:\n  app:\n    image: user/app\n";
-
-  try {
-    await writeFile(targetPath, source);
-    await symlink(targetPath, composePath);
-
-    const result = await writeComposeDocument(cwd, "compose.yaml", {
-      services: { app: { image: "new/app" } },
+    const result = await readComposeDocument("/project", "compose.yaml", {
+      // Preserve the async file-system adapter contract in this test double.
+      // oxlint-disable-next-line require-await
+      readFile: async () => {
+        throw unreadable;
+      },
+      // Preserve the async file-system adapter contract in this test double.
+      // oxlint-disable-next-line require-await
+      stat: async () => ({ isFile: () => true }),
     });
 
     expect(result.isErr()).toBeTruthy();
@@ -549,208 +454,318 @@ test("rejects a symlinked Compose path without replacing the link", async () => 
 
     expect(result.error).toStrictEqual({
       fileName: "compose.yaml",
-      kind: "symlinked-document",
+      kind: "read-failure",
     });
-    const composeStats = await lstat(composePath);
-    expect(composeStats.isSymbolicLink()).toBeTruthy();
-    expect(await readFile(targetPath, "utf-8")).toBe(source);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
+  });
 
-test("rejects a stale revision without overwriting newer Compose content", async () => {
-  const cwd = await createTempDirectory();
-  const composePath = path.join(cwd, "compose.yaml");
-  const newerSource = "services:\n  app:\n    image: newer/app\n";
+  test("replaces an existing Compose document through the write seam", async () => {
+    const cwd = await createTempDirectory();
+    const composePath = path.join(cwd, "compose.yaml");
 
-  try {
-    await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
+    try {
+      await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
 
-    const readResult = await readComposeDocument(cwd, "compose.yaml");
-    expect(readResult.isOk()).toBeTruthy();
-    if (readResult.isErr()) {
-      return;
+      const readResult = await readComposeDocument(cwd, "compose.yaml");
+      expect(readResult.isOk()).toBeTruthy();
+      if (readResult.isErr()) {
+        return;
+      }
+
+      const writeResult = await writeComposeDocument(
+        cwd,
+        "compose.yaml",
+        { services: { app: { image: "new/app" } } },
+        readResult.value.revision
+      );
+
+      expect(writeResult.isOk()).toBeTruthy();
+      await expect(readFile(composePath, "utf-8")).resolves.toContain(
+        "image: new/app"
+      );
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    await writeFile(composePath, newerSource);
+  test("preserves an existing Compose file's permission mode bits", async () => {
+    const cwd = await createTempDirectory();
+    const composePath = path.join(cwd, "compose.yaml");
 
-    const writeResult = await writeComposeDocument(
-      cwd,
-      "compose.yaml",
-      { services: { app: { image: "generated/app" } } },
-      readResult.value.revision
-    );
+    try {
+      await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
+      await chmod(composePath, 0o640);
 
-    expect(writeResult.isErr()).toBeTruthy();
-    if (writeResult.isOk()) {
-      return;
+      const readResult = await readComposeDocument(cwd, "compose.yaml");
+      expect(readResult.isOk()).toBeTruthy();
+      if (readResult.isErr()) {
+        return;
+      }
+
+      const writeResult = await writeComposeDocument(
+        cwd,
+        "compose.yaml",
+        { services: { app: { image: "new/app" } } },
+        readResult.value.revision
+      );
+
+      expect(writeResult.isOk()).toBeTruthy();
+      const composeStats = await lstat(composePath);
+      expect(composeStats.mode % 0o1_0000).toBe(0o640);
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    expect(writeResult.error).toStrictEqual({
-      fileName: "compose.yaml",
-      kind: "stale-document",
-    });
-    expect(await readFile(composePath, "utf-8")).toBe(newerSource);
-    const directoryEntries = await readdir(cwd);
-    expect(
-      directoryEntries.filter((name) => name.startsWith(".compose.yaml."))
-    ).toStrictEqual([]);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
+  test("uses normal filesystem defaults when creating a new Compose file", async () => {
+    const cwd = await createTempDirectory();
+    const composePath = path.join(cwd, "compose.yaml");
+    const expectedPath = path.join(cwd, "expected-mode.txt");
 
-test("reports serialization failures without touching an existing file", async () => {
-  const cwd = await createTempDirectory();
-  const composePath = path.join(cwd, "compose.yaml");
-  const source = "services:\n  app:\n    image: old/app\n";
+    try {
+      await writeFile(expectedPath, "");
+      const expectedStats = await lstat(expectedPath);
+      const expectedMode = expectedStats.mode % 0o1000;
 
-  try {
-    await writeFile(composePath, source);
-    const readResult = await readComposeDocument(cwd, "compose.yaml");
-    expect(readResult.isOk()).toBeTruthy();
-    if (readResult.isErr()) {
-      return;
+      const result = await writeComposeDocument(cwd, "compose.yaml", {
+        services: {},
+      });
+
+      expect(result.isOk()).toBeTruthy();
+      const composeStats = await lstat(composePath);
+      expect(composeStats.mode % 0o1000).toBe(expectedMode);
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    const unserializableDocument = {
-      services: {},
-      value: Symbol("unsupported"),
-    };
+  test("rejects a symlinked Compose path without replacing the link", async () => {
+    const cwd = await createTempDirectory();
+    const targetPath = path.join(cwd, "user-compose.yaml");
+    const composePath = path.join(cwd, "compose.yaml");
+    const source = "services:\n  app:\n    image: user/app\n";
 
-    const writeResult = await writeComposeDocument(
-      cwd,
-      "compose.yaml",
-      unserializableDocument,
-      readResult.value.revision
-    );
+    try {
+      await writeFile(targetPath, source);
+      await symlink(targetPath, composePath);
 
-    expect(writeResult.isErr()).toBeTruthy();
-    if (writeResult.isOk()) {
-      return;
+      const result = await writeComposeDocument(cwd, "compose.yaml", {
+        services: { app: { image: "new/app" } },
+      });
+
+      expect(result.isErr()).toBeTruthy();
+      if (result.isOk()) {
+        return;
+      }
+
+      expect(result.error).toStrictEqual({
+        fileName: "compose.yaml",
+        kind: "symlinked-document",
+      });
+      const composeStats = await lstat(composePath);
+      expect(composeStats.isSymbolicLink()).toBeTruthy();
+      await expect(readFile(targetPath, "utf-8")).resolves.toBe(source);
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    expect(writeResult.error).toStrictEqual({
-      fileName: "compose.yaml",
-      kind: "serialization-failure",
-    });
-    expect(await readFile(composePath, "utf-8")).toBe(source);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
+  test("rejects a stale revision without overwriting newer Compose content", async () => {
+    const cwd = await createTempDirectory();
+    const composePath = path.join(cwd, "compose.yaml");
+    const newerSource = "services:\n  app:\n    image: newer/app\n";
 
-test("reports deterministic write failures without replacing the original", async () => {
-  const cwd = await createTempDirectory();
-  const composePath = path.join(cwd, "compose.yaml");
-  const source = "services:\n  app:\n    image: old/app\n";
+    try {
+      await writeFile(composePath, "services:\n  app:\n    image: old/app\n");
 
-  try {
-    await writeFile(composePath, source);
-    const readResult = await readComposeDocument(cwd, "compose.yaml");
-    expect(readResult.isOk()).toBeTruthy();
-    if (readResult.isErr()) {
-      return;
+      const readResult = await readComposeDocument(cwd, "compose.yaml");
+      expect(readResult.isOk()).toBeTruthy();
+      if (readResult.isErr()) {
+        return;
+      }
+
+      await writeFile(composePath, newerSource);
+
+      const writeResult = await writeComposeDocument(
+        cwd,
+        "compose.yaml",
+        { services: { app: { image: "generated/app" } } },
+        readResult.value.revision
+      );
+
+      expect(writeResult.isErr()).toBeTruthy();
+      if (writeResult.isOk()) {
+        return;
+      }
+
+      expect(writeResult.error).toStrictEqual({
+        fileName: "compose.yaml",
+        kind: "stale-document",
+      });
+      await expect(readFile(composePath, "utf-8")).resolves.toBe(newerSource);
+      const directoryEntries = await readdir(cwd);
+      expect(
+        directoryEntries.filter((name) => name.startsWith(".compose.yaml."))
+      ).toStrictEqual([]);
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    const writeResult = await writeComposeDocument(
-      cwd,
-      "compose.yaml",
-      { services: { app: { image: "new/app" } } },
-      readResult.value.revision,
-      createFileSystem({
-        // Preserve the async file-system adapter contract in this test double.
-        // oxlint-disable-next-line require-await
-        writeFile: async () => {
-          throw new Error("disk full");
-        },
-      })
-    );
+  test("reports serialization failures without touching an existing file", async () => {
+    const cwd = await createTempDirectory();
+    const composePath = path.join(cwd, "compose.yaml");
+    const source = "services:\n  app:\n    image: old/app\n";
 
-    expect(writeResult.isErr()).toBeTruthy();
-    if (writeResult.isOk()) {
-      return;
+    try {
+      await writeFile(composePath, source);
+      const readResult = await readComposeDocument(cwd, "compose.yaml");
+      expect(readResult.isOk()).toBeTruthy();
+      if (readResult.isErr()) {
+        return;
+      }
+
+      const unserializableDocument = {
+        services: {},
+        value: Symbol("unsupported"),
+      };
+
+      const writeResult = await writeComposeDocument(
+        cwd,
+        "compose.yaml",
+        unserializableDocument,
+        readResult.value.revision
+      );
+
+      expect(writeResult.isErr()).toBeTruthy();
+      if (writeResult.isOk()) {
+        return;
+      }
+
+      expect(writeResult.error).toStrictEqual({
+        fileName: "compose.yaml",
+        kind: "serialization-failure",
+      });
+      await expect(readFile(composePath, "utf-8")).resolves.toBe(source);
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    expect(writeResult.error).toStrictEqual({
-      fileName: "compose.yaml",
-      kind: "write-failure",
-    });
-    expect(await readFile(composePath, "utf-8")).toBe(source);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
+  test("reports deterministic write failures without replacing the original", async () => {
+    const cwd = await createTempDirectory();
+    const composePath = path.join(cwd, "compose.yaml");
+    const source = "services:\n  app:\n    image: old/app\n";
 
-test("creates a new Compose file exclusively when another process wins the race", async () => {
-  const cwd = await createTempDirectory();
-  const composePath = path.join(cwd, "compose.yaml");
-  const competitorSource = "services:\n  competitor:\n    image: other/app\n";
+    try {
+      await writeFile(composePath, source);
+      const readResult = await readComposeDocument(cwd, "compose.yaml");
+      expect(readResult.isOk()).toBeTruthy();
+      if (readResult.isErr()) {
+        return;
+      }
 
-  try {
-    const writeResult = await writeComposeDocument(
-      cwd,
-      "compose.yaml",
-      { services: { app: { image: "new/app" } } },
-      undefined,
-      createFileSystem({
-        link: async (_temporaryPath, newPath) => {
-          await writeFile(newPath, competitorSource);
-          throw Object.assign(new Error("already exists"), { code: "EEXIST" });
-        },
-      })
-    );
+      const writeResult = await writeComposeDocument(
+        cwd,
+        "compose.yaml",
+        { services: { app: { image: "new/app" } } },
+        readResult.value.revision,
+        createFileSystem({
+          // Preserve the async file-system adapter contract in this test double.
+          // oxlint-disable-next-line require-await
+          writeFile: async () => {
+            throw new Error("disk full");
+          },
+        })
+      );
 
-    expect(writeResult.isErr()).toBeTruthy();
-    if (writeResult.isOk()) {
-      return;
+      expect(writeResult.isErr()).toBeTruthy();
+      if (writeResult.isOk()) {
+        return;
+      }
+
+      expect(writeResult.error).toStrictEqual({
+        fileName: "compose.yaml",
+        kind: "write-failure",
+      });
+      await expect(readFile(composePath, "utf-8")).resolves.toBe(source);
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    expect(writeResult.error).toStrictEqual({
-      fileName: "compose.yaml",
-      kind: "creation-conflict",
-    });
-    expect(await readFile(composePath, "utf-8")).toBe(competitorSource);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
-});
+  test("creates a new Compose file exclusively when another process wins the race", async () => {
+    const cwd = await createTempDirectory();
+    const composePath = path.join(cwd, "compose.yaml");
+    const competitorSource = "services:\n  competitor:\n    image: other/app\n";
 
-test("reports replacement failures without leaving a temporary file", async () => {
-  const cwd = await createTempDirectory();
-  const composePath = path.join(cwd, "compose.yaml");
-  const source = "services:\n  app:\n    image: old/app\n";
+    try {
+      const writeResult = await writeComposeDocument(
+        cwd,
+        "compose.yaml",
+        { services: { app: { image: "new/app" } } },
+        undefined,
+        createFileSystem({
+          link: async (_temporaryPath, newPath) => {
+            await writeFile(newPath, competitorSource);
+            throw Object.assign(new Error("already exists"), {
+              code: "EEXIST",
+            });
+          },
+        })
+      );
 
-  try {
-    await writeFile(composePath, source);
-    const readResult = await readComposeDocument(cwd, "compose.yaml");
-    expect(readResult.isOk()).toBeTruthy();
-    if (readResult.isErr()) {
-      return;
+      expect(writeResult.isErr()).toBeTruthy();
+      if (writeResult.isOk()) {
+        return;
+      }
+
+      expect(writeResult.error).toStrictEqual({
+        fileName: "compose.yaml",
+        kind: "creation-conflict",
+      });
+      await expect(readFile(composePath, "utf-8")).resolves.toBe(
+        competitorSource
+      );
+    } finally {
+      await removeTempDirectory(cwd);
     }
+  });
 
-    const writeResult = await writeComposeDocument(
-      cwd,
-      "compose.yaml",
-      { services: { app: { image: "new/app" } } },
-      readResult.value.revision,
-      createFileSystem({
-        // Preserve the async file-system adapter contract in this test double.
-        // oxlint-disable-next-line require-await
-        rename: async () => {
-          throw new Error("rename failed");
-        },
-      })
-    );
+  test("reports replacement failures without leaving a temporary file", async () => {
+    const cwd = await createTempDirectory();
+    const composePath = path.join(cwd, "compose.yaml");
+    const source = "services:\n  app:\n    image: old/app\n";
 
-    expect(writeResult.isErr()).toBeTruthy();
-    expect(await readFile(composePath, "utf-8")).toBe(source);
-    const directoryEntries = await readdir(cwd);
-    expect(
-      directoryEntries.filter((name) => name.startsWith(".compose.yaml."))
-    ).toStrictEqual([]);
-  } finally {
-    await removeTempDirectory(cwd);
-  }
+    try {
+      await writeFile(composePath, source);
+      const readResult = await readComposeDocument(cwd, "compose.yaml");
+      expect(readResult.isOk()).toBeTruthy();
+      if (readResult.isErr()) {
+        return;
+      }
+
+      const writeResult = await writeComposeDocument(
+        cwd,
+        "compose.yaml",
+        { services: { app: { image: "new/app" } } },
+        readResult.value.revision,
+        createFileSystem({
+          // Preserve the async file-system adapter contract in this test double.
+          // oxlint-disable-next-line require-await
+          rename: async () => {
+            throw new Error("rename failed");
+          },
+        })
+      );
+
+      expect(writeResult.isErr()).toBeTruthy();
+      await expect(readFile(composePath, "utf-8")).resolves.toBe(source);
+      const directoryEntries = await readdir(cwd);
+      expect(
+        directoryEntries.filter((name) => name.startsWith(".compose.yaml."))
+      ).toStrictEqual([]);
+    } finally {
+      await removeTempDirectory(cwd);
+    }
+  });
 });

--- a/packages/cli/src/commands/docker/helpers/format-compose-file-failure.test.ts
+++ b/packages/cli/src/commands/docker/helpers/format-compose-file-failure.test.ts
@@ -1,12 +1,14 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { formatComposeFileFailure } from "./format-compose-file-failure";
 
-test("requires an explicit rerun after a stale Compose document failure", () => {
-  expect(
-    formatComposeFileFailure({
-      fileName: "compose.yaml",
-      kind: "stale-document",
-    })
-  ).toContain("Rerun the command explicitly");
+describe("Compose file failure formatting", () => {
+  test("requires an explicit rerun after a stale Compose document failure", () => {
+    expect(
+      formatComposeFileFailure({
+        fileName: "compose.yaml",
+        kind: "stale-document",
+      })
+    ).toContain("Rerun the command explicitly");
+  });
 });

--- a/packages/cli/src/commands/docker/helpers/init-docker-concurrency.test.ts
+++ b/packages/cli/src/commands/docker/helpers/init-docker-concurrency.test.ts
@@ -2,7 +2,9 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+
+import type { enhancedConfirm, enhancedText } from "~/utils/prompts";
 
 import { DOCKER_DATABASES } from "../databases";
 
@@ -12,59 +14,68 @@ type PostgresConfig = Awaited<
 type MysqlConfig = Awaited<ReturnType<(typeof DOCKER_DATABASES)[1]["config"]>>;
 
 const promptMocks = vi.hoisted(() => ({
-  enhancedConfirm: vi.fn().mockResolvedValue(true),
-  enhancedMultiselect: vi.fn().mockResolvedValue(["postgresql", "mysql"]),
-  enhancedSelect: vi.fn().mockResolvedValue("latest"),
-  enhancedText: vi.fn().mockImplementation(
+  enhancedConfirm: vi.fn<typeof enhancedConfirm>().mockResolvedValue(true),
+  // Vitest's Mock type cannot preserve the generic multiselect signature required by the module factory.
+  enhancedMultiselect: vi
+    // oxlint-disable-next-line typescript/no-explicit-any
+    .fn<(...args: any[]) => Promise<any>>()
+    .mockResolvedValue(["postgresql", "mysql"]),
+  // Vitest's Mock type cannot preserve the generic select signature required by the module factory.
+  enhancedSelect: vi
+    // oxlint-disable-next-line typescript/no-explicit-any
+    .fn<(...args: any[]) => Promise<any>>()
+    .mockResolvedValue("latest"),
+  enhancedText: vi.fn<typeof enhancedText>().mockImplementation(
     // Return each requested default so generated service names stay distinct.
-    // oxlint-disable-next-line typescript/promise-function-async
-    ({ defaultValue }: { defaultValue?: string }) =>
-      Promise.resolve(defaultValue ?? "")
+    // oxlint-disable-next-line require-await
+    async ({ defaultValue }) => defaultValue ?? ""
   ),
 }));
 
 vi.mock(import("~/utils/prompts"), () => promptMocks);
 
-test("initDocker loads selected database configurations concurrently", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
-  const postgresConfigDeferred = Promise.withResolvers<PostgresConfig>();
-  const mysqlConfigDeferred = Promise.withResolvers<MysqlConfig>();
-  const postgresLoader = vi
-    .spyOn(DOCKER_DATABASES[0], "config")
-    .mockReturnValue(postgresConfigDeferred.promise);
-  const mysqlLoader = vi
-    .spyOn(DOCKER_DATABASES[1], "config")
-    .mockReturnValue(mysqlConfigDeferred.promise);
+describe("initDocker concurrency", () => {
+  test("initDocker loads selected database configurations concurrently", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
+    const postgresConfigDeferred = Promise.withResolvers<PostgresConfig>();
+    const mysqlConfigDeferred = Promise.withResolvers<MysqlConfig>();
+    const postgresLoader = vi
+      .spyOn(DOCKER_DATABASES[0], "config")
+      .mockReturnValue(postgresConfigDeferred.promise);
+    const mysqlLoader = vi
+      .spyOn(DOCKER_DATABASES[1], "config")
+      .mockReturnValue(mysqlConfigDeferred.promise);
 
-  await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
+    await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
 
-  try {
-    const { initDocker } = await import("./init-docker");
-    const resultPromise = initDocker({ cwd });
+    try {
+      const { initDocker } = await import("./init-docker");
+      const resultPromise = initDocker({ cwd });
 
-    await expect.poll(() => mysqlLoader.mock.calls.length).toBe(1);
-    expect(postgresLoader).toHaveBeenCalledOnce();
+      await expect.poll(() => mysqlLoader.mock.calls.length).toBe(1);
+      expect(postgresLoader).toHaveBeenCalledOnce();
 
-    const [{ config: postgresConfig }, { config: mysqlConfig }] =
-      await Promise.all([
-        import("../databases/postgresql"),
-        import("../databases/mysql"),
-      ]);
-    postgresConfigDeferred.resolve(postgresConfig);
-    mysqlConfigDeferred.resolve(mysqlConfig);
+      const [{ config: postgresConfig }, { config: mysqlConfig }] =
+        await Promise.all([
+          import("../databases/postgresql"),
+          import("../databases/mysql"),
+        ]);
+      postgresConfigDeferred.resolve(postgresConfig);
+      mysqlConfigDeferred.resolve(mysqlConfig);
 
-    const result = await resultPromise;
-    expect(result.isOk()).toBeTruthy();
-    if (result.isErr()) {
-      return;
+      const result = await resultPromise;
+      expect(result.isOk()).toBeTruthy();
+      if (result.isErr()) {
+        return;
+      }
+
+      expect(
+        result.value.imageConfigs.map(({ repository }) => repository)
+      ).toStrictEqual(["postgres", "mysql"]);
+    } finally {
+      postgresLoader.mockRestore();
+      mysqlLoader.mockRestore();
+      await rm(cwd, { force: true, recursive: true });
     }
-
-    expect(
-      result.value.imageConfigs.map(({ repository }) => repository)
-    ).toStrictEqual(["postgres", "mysql"]);
-  } finally {
-    postgresLoader.mockRestore();
-    mysqlLoader.mockRestore();
-    await rm(cwd, { force: true, recursive: true });
-  }
+  });
 });

--- a/packages/cli/src/commands/docker/helpers/init-docker.test.ts
+++ b/packages/cli/src/commands/docker/helpers/init-docker.test.ts
@@ -2,26 +2,34 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { parse } from "yaml";
+
+import type { enhancedConfirm, enhancedText } from "~/utils/prompts";
 
 const promptMocks = vi.hoisted(() => ({
   // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-  // oxlint-disable-next-line require-await
-  enhancedConfirm: vi.fn(async () => true),
+  enhancedConfirm: vi.fn<typeof enhancedConfirm>().mockResolvedValue(true),
   // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-  // oxlint-disable-next-line require-await
-  enhancedMultiselect: vi.fn().mockImplementation(async () => ["postgresql"]),
-  enhancedSelect: vi.fn().mockImplementation(
+  // Vitest's Mock type cannot preserve the generic multiselect signature required by the module factory.
+  enhancedMultiselect: vi
+    // oxlint-disable-next-line typescript/no-explicit-any
+    .fn<(...args: any[]) => Promise<any>>()
+    .mockResolvedValue(["postgresql"]),
+  // Vitest's Mock type cannot preserve the generic select signature required by the module factory.
+  enhancedSelect: vi
+    // oxlint-disable-next-line typescript/no-explicit-any
+    .fn<(...args: any[]) => Promise<any>>()
+    .mockImplementation(
+      // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
+      // oxlint-disable-next-line require-await
+      async ({ initialValue }: { initialValue?: string }) =>
+        initialValue ?? "latest"
+    ),
+  enhancedText: vi.fn<typeof enhancedText>(
     // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
     // oxlint-disable-next-line require-await
-    async ({ initialValue }: { initialValue?: string }) =>
-      initialValue ?? "latest"
-  ),
-  enhancedText: vi.fn(
-    // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-    // oxlint-disable-next-line require-await
-    async ({ defaultValue }: { defaultValue?: string }) => defaultValue ?? ""
+    async ({ defaultValue }) => defaultValue ?? ""
   ),
 }));
 
@@ -43,170 +51,174 @@ async function createComposeFixture(
   return cwd;
 }
 
-test("initDocker writes the transformed document after service selection", async () => {
-  const cwd = await createComposeFixture();
+describe("initDocker", () => {
+  test("initDocker writes the transformed document after service selection", async () => {
+    const cwd = await createComposeFixture();
 
-  try {
-    const { initDocker } = await import("./init-docker");
-    const result = await initDocker({ cwd });
+    try {
+      const { initDocker } = await import("./init-docker");
+      const result = await initDocker({ cwd });
 
-    expect(result.isOk()).toBeTruthy();
-    const document: unknown = parse(
-      await readFile(path.join(cwd, "compose.yaml"), "utf-8")
-    );
+      expect(result.isOk()).toBeTruthy();
+      const document: unknown = parse(
+        await readFile(path.join(cwd, "compose.yaml"), "utf-8")
+      );
 
-    expect(document).toStrictEqual({
-      name: "example",
-      services: {
-        app: {
-          image: "example/app",
-          labels: { "com.example.owner": "user" },
-        },
-        postgres: {
-          environment: {
-            POSTGRES_DB: "docker",
-            POSTGRES_PASSWORD: "docker",
-            POSTGRES_USER: "docker",
+      expect(document).toStrictEqual({
+        name: "example",
+        services: {
+          app: {
+            image: "example/app",
+            labels: { "com.example.owner": "user" },
           },
-          healthcheck: {
-            interval: "10s",
-            retries: 5,
-            test: ["CMD-SHELL", "pg_isready -U docker -d docker"],
-            timeout: "5s",
+          postgres: {
+            environment: {
+              POSTGRES_DB: "docker",
+              POSTGRES_PASSWORD: "docker",
+              POSTGRES_USER: "docker",
+            },
+            healthcheck: {
+              interval: "10s",
+              retries: 5,
+              test: ["CMD-SHELL", "pg_isready -U docker -d docker"],
+              timeout: "5s",
+            },
+            image: "postgres:latest",
+            ports: ["5432:5432"],
+            volumes: ["postgres_data:/var/lib/postgresql/data"],
           },
-          image: "postgres:latest",
-          ports: ["5432:5432"],
-          volumes: ["postgres_data:/var/lib/postgresql/data"],
         },
-      },
-      volumes: {
-        postgres_data: {},
-        shared_data: { labels: { "com.example.owner": "user" } },
-      },
-    });
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
-
-test("initDocker preserves selected database order during configuration loading", async () => {
-  const cwd = await createComposeFixture();
-  promptMocks.enhancedMultiselect.mockImplementationOnce(
-    // Preserve the async prompt helper contract in this test double.
-    // oxlint-disable-next-line require-await
-    async () => ["postgresql", "mysql"]
-  );
-
-  try {
-    const { initDocker } = await import("./init-docker");
-    const result = await initDocker({ cwd });
-
-    expect(result.isOk()).toBeTruthy();
-    if (result.isErr()) {
-      return;
+        volumes: {
+          postgres_data: {},
+          shared_data: { labels: { "com.example.owner": "user" } },
+        },
+      });
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
     }
-
-    expect(
-      result.value.imageConfigs.map(({ repository }) => repository)
-    ).toStrictEqual(["postgres", "mysql"]);
-    expect(
-      result.value.connectionConfigs.map(({ type }) => type)
-    ).toStrictEqual(["postgresql", "mysql"]);
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
-
-test("initDocker reports a service collision without writing a partial batch", async () => {
-  const cwd = await createComposeFixture({
-    services:
-      "  postgres:\n    image: user/postgres\n  app:\n    image: example/app",
   });
-  const original = await readFile(path.join(cwd, "compose.yaml"), "utf-8");
 
-  try {
-    const { initDocker } = await import("./init-docker");
-    const result = await initDocker({ cwd });
-
-    expect(result.isErr()).toBeTruthy();
-    if (result.isOk()) {
-      return;
-    }
-
-    expect(result.error).toContain('service name "postgres"');
-    await expect(
-      readFile(path.join(cwd, "compose.yaml"), "utf-8")
-    ).resolves.toBe(original);
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
-
-test("initDocker returns a parse failure without writing the Compose file", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
-  const composePath = path.join(cwd, "compose.yaml");
-  const invalidDocument = "services:\n  app: [";
-  await writeFile(composePath, invalidDocument);
-
-  try {
-    const { initDocker } = await import("./init-docker");
-    const result = await initDocker({ cwd });
-
-    expect(result.isErr()).toBeTruthy();
-    if (result.isOk()) {
-      return;
-    }
-
-    expect(result.error).toBe(
-      "Failed to parse existing Docker Compose file: compose.yaml"
+  test("initDocker preserves selected database order during configuration loading", async () => {
+    const cwd = await createComposeFixture();
+    promptMocks.enhancedMultiselect.mockImplementationOnce(
+      // Preserve the async prompt helper contract in this test double.
+      // oxlint-disable-next-line require-await
+      async () => ["postgresql", "mysql"]
     );
-    expect(await readFile(composePath, "utf-8")).toBe(invalidDocument);
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
 
-test("initDocker prompts for a candidate when multiple Compose files exist", async () => {
-  const cwd = await createComposeFixture();
-  const alternatePath = path.join(cwd, "docker-compose.yml");
-  const alternateSource = `name: alternate
+    try {
+      const { initDocker } = await import("./init-docker");
+      const result = await initDocker({ cwd });
+
+      expect(result.isOk()).toBeTruthy();
+      if (result.isErr()) {
+        return;
+      }
+
+      expect(
+        result.value.imageConfigs.map(({ repository }) => repository)
+      ).toStrictEqual(["postgres", "mysql"]);
+      expect(
+        result.value.connectionConfigs.map(({ type }) => type)
+      ).toStrictEqual(["postgresql", "mysql"]);
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test("initDocker reports a service collision without writing a partial batch", async () => {
+    const cwd = await createComposeFixture({
+      services:
+        "  postgres:\n    image: user/postgres\n  app:\n    image: example/app",
+    });
+    const original = await readFile(path.join(cwd, "compose.yaml"), "utf-8");
+
+    try {
+      const { initDocker } = await import("./init-docker");
+      const result = await initDocker({ cwd });
+
+      expect(result.isErr()).toBeTruthy();
+      if (result.isOk()) {
+        return;
+      }
+
+      expect(result.error).toContain('service name "postgres"');
+      await expect(
+        readFile(path.join(cwd, "compose.yaml"), "utf-8")
+      ).resolves.toBe(original);
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test("initDocker returns a parse failure without writing the Compose file", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
+    const composePath = path.join(cwd, "compose.yaml");
+    const invalidDocument = "services:\n  app: [";
+    await writeFile(composePath, invalidDocument);
+
+    try {
+      const { initDocker } = await import("./init-docker");
+      const result = await initDocker({ cwd });
+
+      expect(result.isErr()).toBeTruthy();
+      if (result.isOk()) {
+        return;
+      }
+
+      expect(result.error).toBe(
+        "Failed to parse existing Docker Compose file: compose.yaml"
+      );
+      await expect(readFile(composePath, "utf-8")).resolves.toBe(
+        invalidDocument
+      );
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test("initDocker prompts for a candidate when multiple Compose files exist", async () => {
+    const cwd = await createComposeFixture();
+    const alternatePath = path.join(cwd, "docker-compose.yml");
+    const alternateSource = `name: alternate
 services:
   app:
     image: alternate/app
   `;
-  await writeFile(alternatePath, alternateSource);
-  promptMocks.enhancedSelect.mockImplementationOnce(
-    // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-    // oxlint-disable-next-line require-await
-    async () => "docker-compose.yml"
-  );
+    await writeFile(alternatePath, alternateSource);
+    promptMocks.enhancedSelect.mockResolvedValueOnce("docker-compose.yml");
 
-  try {
-    const { initDocker } = await import("./init-docker");
-    const result = await initDocker({ cwd });
+    try {
+      const { initDocker } = await import("./init-docker");
+      const result = await initDocker({ cwd });
 
-    expect(result.isOk()).toBeTruthy();
-    expect(await readFile(alternatePath, "utf-8")).not.toBe(alternateSource);
-    expect(await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toBe(
-      "name: example\nservices:\n  app:\n    image: example/app\n    labels:\n      com.example.owner: user\nvolumes:\n  shared_data:\n    labels:\n      com.example.owner: user\n"
-    );
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
+      expect(result.isOk()).toBeTruthy();
+      await expect(readFile(alternatePath, "utf-8")).resolves.not.toBe(
+        alternateSource
+      );
+      await expect(
+        readFile(path.join(cwd, "compose.yaml"), "utf-8")
+      ).resolves.toBe(
+        "name: example\nservices:\n  app:\n    image: example/app\n    labels:\n      com.example.owner: user\nvolumes:\n  shared_data:\n    labels:\n      com.example.owner: user\n"
+      );
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 
-test("initDocker prompts for a supported filename when no Compose file exists", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
+  test("initDocker prompts for a supported filename when no Compose file exists", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-"));
 
-  try {
-    const { initDocker } = await import("./init-docker");
-    const result = await initDocker({ cwd });
+    try {
+      const { initDocker } = await import("./init-docker");
+      const result = await initDocker({ cwd });
 
-    expect(result.isOk()).toBeTruthy();
-    expect(await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toContain(
-      "services:"
-    );
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
+      expect(result.isOk()).toBeTruthy();
+      await expect(
+        readFile(path.join(cwd, "compose.yaml"), "utf-8")
+      ).resolves.toContain("services:");
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 });

--- a/packages/cli/src/commands/docker/init.test.ts
+++ b/packages/cli/src/commands/docker/init.test.ts
@@ -2,33 +2,42 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+
+import type { handleError } from "~/utils/handle-error";
+import type { enhancedConfirm, enhancedText } from "~/utils/prompts";
 
 const { confirmResults, handleErrorMock, promptMocks } = vi.hoisted(() => {
   const mockConfirmResults = [true, true];
   // Keep the synchronous handleError contract so mocked command failures stop
   // execution just like the process-exiting production implementation.
-  // oxlint-disable-next-line promise/prefer-await-to-callbacks
-  const mockHandleError = vi.fn((error: string): never => {
-    throw new Error(error);
-  });
+  const mockHandleError = vi.fn<typeof handleError>(
+    // oxlint-disable-next-line promise/prefer-await-to-callbacks
+    (error: string): never => {
+      throw new Error(error);
+    }
+  );
   const mockPromptMocks = {
     // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-    // oxlint-disable-next-line require-await
-    enhancedConfirm: vi.fn(async () => mockConfirmResults.shift() ?? true),
-    // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-    // oxlint-disable-next-line require-await
-    enhancedMultiselect: vi.fn().mockImplementation(async () => ["postgresql"]),
-    enhancedSelect: vi.fn().mockImplementation(
-      // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
+    enhancedConfirm: vi.fn<typeof enhancedConfirm>().mockImplementation(
       // oxlint-disable-next-line require-await
-      async ({ initialValue }: { initialValue?: string }) =>
-        initialValue ?? "latest"
+      async () => mockConfirmResults.shift() ?? true
     ),
-    enhancedText: vi.fn(
+    // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
+    // Vitest's Mock type cannot preserve the generic multiselect signature required by the module factory.
+    enhancedMultiselect: vi
+      // oxlint-disable-next-line typescript/no-explicit-any
+      .fn<(...args: any[]) => Promise<any>>()
+      .mockResolvedValue(["postgresql"]),
+    // Vitest's Mock type cannot preserve the generic select signature required by the module factory.
+    enhancedSelect: vi
+      // oxlint-disable-next-line typescript/no-explicit-any
+      .fn<(...args: any[]) => Promise<any>>()
+      .mockResolvedValue("latest"),
+    enhancedText: vi.fn<typeof enhancedText>(
       // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
       // oxlint-disable-next-line require-await
-      async ({ defaultValue }: { defaultValue?: string }) => defaultValue ?? ""
+      async ({ defaultValue }) => defaultValue ?? ""
     ),
   };
 
@@ -51,146 +60,141 @@ async function createComposeFixture(): Promise<string> {
   return cwd;
 }
 
-test("init reports an environment failure after the Compose file is written", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-docker-init-"));
-  const envPath = path.join(cwd, "env-directory");
-  await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
-  await mkdir(envPath);
-  confirmResults.splice(0, confirmResults.length, true, true);
+describe("init command", () => {
+  test("init reports an environment failure after the Compose file is written", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-docker-init-"));
+    const envPath = path.join(cwd, "env-directory");
+    await writeFile(path.join(cwd, "compose.yaml"), "services: {}\n");
+    await mkdir(envPath);
+    confirmResults.splice(0, confirmResults.length, true, true);
 
-  try {
-    const { init } = await import("./init");
+    try {
+      const { init } = await import("./init");
 
-    await expect(
-      init.parseAsync([
+      await expect(
+        init.parseAsync([
+          "node",
+          "ayanokoji",
+          "--cwd",
+          cwd,
+          "--env-path",
+          envPath,
+        ])
+      ).rejects.toThrow(
+        "Docker Compose file was written successfully, but environment synchronization failed"
+      );
+
+      await expect(
+        readFile(path.join(cwd, "compose.yaml"), "utf-8")
+      ).resolves.toContain("postgres:");
+      expect(handleErrorMock).toHaveBeenCalledOnce();
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test("init synchronizes the environment after a successful Compose write", async () => {
+    const cwd = await createComposeFixture();
+    const envPath = path.join(cwd, ".env.local");
+    confirmResults.splice(0, confirmResults.length, true, true);
+
+    try {
+      const { init } = await import("./init");
+      await init.parseAsync([
         "node",
         "ayanokoji",
         "--cwd",
         cwd,
         "--env-path",
         envPath,
-      ])
-    ).rejects.toThrow(
-      "Docker Compose file was written successfully, but environment synchronization failed"
-    );
+      ]);
 
-    expect(await readFile(path.join(cwd, "compose.yaml"), "utf-8")).toContain(
-      "postgres:"
-    );
-    expect(handleErrorMock).toHaveBeenCalledOnce();
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
+      await expect(readFile(envPath, "utf-8")).resolves.toContain(
+        "POSTGRESQL_URL=postgresql://docker:docker@localhost:5432/docker"
+      );
+      await expect(
+        readFile(path.join(cwd, ".gitignore"), "utf-8")
+      ).resolves.toBe(".env\n");
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 
-test("init synchronizes the environment after a successful Compose write", async () => {
-  const cwd = await createComposeFixture();
-  const envPath = path.join(cwd, ".env.local");
-  confirmResults.splice(0, confirmResults.length, true, true);
+  test("init skips existing environment variables when requested", async () => {
+    const cwd = await createComposeFixture();
+    const envPath = path.join(cwd, ".env.local");
+    const existingEnv = "POSTGRESQL_URL=existing\n";
+    await writeFile(envPath, existingEnv);
+    confirmResults.splice(0, confirmResults.length, true, true);
 
-  try {
-    const { init } = await import("./init");
-    await init.parseAsync([
-      "node",
-      "ayanokoji",
-      "--cwd",
-      cwd,
-      "--env-path",
-      envPath,
-    ]);
+    try {
+      const { init } = await import("./init");
+      await init.parseAsync([
+        "node",
+        "ayanokoji",
+        "--cwd",
+        cwd,
+        "--env-path",
+        envPath,
+        "--skip-conflicts",
+      ]);
 
-    expect(await readFile(envPath, "utf-8")).toContain(
-      "POSTGRESQL_URL=postgresql://docker:docker@localhost:5432/docker"
-    );
-    expect(await readFile(path.join(cwd, ".gitignore"), "utf-8")).toBe(
-      ".env\n"
-    );
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
+      await expect(readFile(envPath, "utf-8")).resolves.toBe(existingEnv);
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 
-test("init skips existing environment variables when requested", async () => {
-  const cwd = await createComposeFixture();
-  const envPath = path.join(cwd, ".env.local");
-  const existingEnv = "POSTGRESQL_URL=existing\n";
-  await writeFile(envPath, existingEnv);
-  confirmResults.splice(0, confirmResults.length, true, true);
+  test("init overrides an existing environment variable when selected", async () => {
+    const cwd = await createComposeFixture();
+    const envPath = path.join(cwd, ".env.local");
+    await writeFile(envPath, "POSTGRESQL_URL=existing\n");
+    confirmResults.splice(0, confirmResults.length, true, true);
+    promptMocks.enhancedSelect
+      .mockResolvedValueOnce("latest")
+      .mockResolvedValueOnce("override");
 
-  try {
-    const { init } = await import("./init");
-    await init.parseAsync([
-      "node",
-      "ayanokoji",
-      "--cwd",
-      cwd,
-      "--env-path",
-      envPath,
-      "--skip-conflicts",
-    ]);
+    try {
+      const { init } = await import("./init");
+      await init.parseAsync([
+        "node",
+        "ayanokoji",
+        "--cwd",
+        cwd,
+        "--env-path",
+        envPath,
+      ]);
 
-    expect(await readFile(envPath, "utf-8")).toBe(existingEnv);
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
+      await expect(readFile(envPath, "utf-8")).resolves.toContain(
+        "POSTGRESQL_URL=postgresql://docker:docker@localhost:5432/docker"
+      );
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 
-test("init overrides an existing environment variable when selected", async () => {
-  const cwd = await createComposeFixture();
-  const envPath = path.join(cwd, ".env.local");
-  await writeFile(envPath, "POSTGRESQL_URL=existing\n");
-  confirmResults.splice(0, confirmResults.length, true, true);
-  promptMocks.enhancedSelect
-    .mockImplementationOnce(
-      // Preserve the database version default before the conflict prompt.
-      // oxlint-disable-next-line require-await
-      async ({ initialValue }: { initialValue?: string }) =>
-        initialValue ?? "latest"
-    )
-    .mockImplementationOnce(
-      // Preserve the async prompt helper contract in this test double.
-      // oxlint-disable-next-line require-await
-      async () => "override"
-    );
+  test("init succeeds without environment changes when synchronization is declined", async () => {
+    const cwd = await createComposeFixture();
+    const envPath = path.join(cwd, ".env.local");
+    confirmResults.splice(0, confirmResults.length, true, false);
 
-  try {
-    const { init } = await import("./init");
-    await init.parseAsync([
-      "node",
-      "ayanokoji",
-      "--cwd",
-      cwd,
-      "--env-path",
-      envPath,
-    ]);
+    try {
+      const { init } = await import("./init");
+      await init.parseAsync([
+        "node",
+        "ayanokoji",
+        "--cwd",
+        cwd,
+        "--env-path",
+        envPath,
+      ]);
 
-    expect(await readFile(envPath, "utf-8")).toContain(
-      "POSTGRESQL_URL=postgresql://docker:docker@localhost:5432/docker"
-    );
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
-
-test("init succeeds without environment changes when synchronization is declined", async () => {
-  const cwd = await createComposeFixture();
-  const envPath = path.join(cwd, ".env.local");
-  confirmResults.splice(0, confirmResults.length, true, false);
-
-  try {
-    const { init } = await import("./init");
-    await init.parseAsync([
-      "node",
-      "ayanokoji",
-      "--cwd",
-      cwd,
-      "--env-path",
-      envPath,
-    ]);
-
-    await expect(readFile(envPath)).rejects.toThrow();
-    await expect(readFile(path.join(cwd, ".gitignore"))).rejects.toThrow();
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
+      await expect(readFile(envPath)).rejects.toThrow("ENOENT");
+      await expect(readFile(path.join(cwd, ".gitignore"))).rejects.toThrow(
+        "ENOENT"
+      );
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 });

--- a/packages/cli/src/commands/docker/remove.test.ts
+++ b/packages/cli/src/commands/docker/remove.test.ts
@@ -9,35 +9,47 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { parse } from "yaml";
+
+import type { handleError } from "~/utils/handle-error";
+import type { enhancedConfirm, enhancedText } from "~/utils/prompts";
 
 const { confirmState, enhancedSelectMock, handleErrorMock, promptMocks } =
   vi.hoisted(() => {
     const mockConfirmState = { value: false };
     // Keep the synchronous handleError contract so mocked command failures stop
     // execution just like the process-exiting production implementation.
-    // oxlint-disable-next-line promise/prefer-await-to-callbacks
-    const mockHandleError = vi.fn((error: string): never => {
-      throw new Error(error);
-    });
-    const mockEnhancedSelect = vi.fn();
+    const mockHandleError = vi.fn<typeof handleError>(
+      // oxlint-disable-next-line promise/prefer-await-to-callbacks
+      (error: string): never => {
+        throw new Error(error);
+      }
+    );
+    // Vitest's Mock type cannot preserve the generic select signature required by the module factory.
+    const mockEnhancedSelect = vi
+      // oxlint-disable-next-line typescript/no-explicit-any
+      .fn<(...args: any[]) => Promise<any>>();
     // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-    // oxlint-disable-next-line require-await
-    mockEnhancedSelect.mockImplementation(async () => "latest");
+    mockEnhancedSelect.mockResolvedValue("latest");
     const mockPromptMocks = {
       // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-      // oxlint-disable-next-line require-await
-      enhancedConfirm: vi.fn(async () => mockConfirmState.value),
-      // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-      // oxlint-disable-next-line require-await
-      enhancedMultiselect: vi.fn().mockImplementation(async () => ["postgres"]),
-      enhancedSelect: mockEnhancedSelect,
-      enhancedText: vi.fn(
+      enhancedConfirm: vi.fn<typeof enhancedConfirm>(
         // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
         // oxlint-disable-next-line require-await
-        async ({ defaultValue }: { defaultValue?: string }) =>
-          defaultValue ?? ""
+        async () => mockConfirmState.value
+      ),
+      // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
+      // Vitest's Mock type cannot preserve the generic multiselect signature required by the module factory.
+      enhancedMultiselect: vi
+        // oxlint-disable-next-line typescript/no-explicit-any
+        .fn<(...args: any[]) => Promise<any>>()
+        .mockResolvedValue(["postgres"]),
+      enhancedSelect: mockEnhancedSelect,
+      enhancedText: vi.fn<typeof enhancedText>(
+        // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
+        // oxlint-disable-next-line require-await
+        async ({ defaultValue }) => defaultValue ?? ""
       ),
     };
 
@@ -55,13 +67,14 @@ vi.mock(import("~/utils/handle-error"), () => ({
 
 vi.mock(import("~/utils/prompts"), () => promptMocks);
 
-test("remove command writes the pure removal result", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
-  const composePath = path.join(cwd, "compose.yaml");
+describe("remove command", () => {
+  test("remove command writes the pure removal result", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+    const composePath = path.join(cwd, "compose.yaml");
 
-  await writeFile(
-    composePath,
-    `name: example
+    await writeFile(
+      composePath,
+      `name: example
 services:
   postgres:
     image: postgres:17
@@ -78,154 +91,159 @@ networks:
   internal:
     driver: bridge
 `
-  );
+    );
 
-  try {
-    const { remove } = await import("./remove");
-    await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
+    try {
+      const { remove } = await import("./remove");
+      await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
 
-    const document: unknown = parse(await readFile(composePath, "utf-8"));
-    expect(document).toStrictEqual({
-      name: "example",
-      networks: {
-        internal: {
-          driver: "bridge",
-        },
-      },
-      services: {
-        app: {
-          image: "example/app",
-        },
-      },
-      volumes: {
-        shared_data: {
-          labels: {
-            owner: "user",
+      const document: unknown = parse(await readFile(composePath, "utf-8"));
+      expect(document).toStrictEqual({
+        name: "example",
+        networks: {
+          internal: {
+            driver: "bridge",
           },
         },
-      },
-    });
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
+        services: {
+          app: {
+            image: "example/app",
+          },
+        },
+        volumes: {
+          shared_data: {
+            labels: {
+              owner: "user",
+            },
+          },
+        },
+      });
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 
-test("remove reports a missing Compose document without creating one", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+  test("remove reports a missing Compose document without creating one", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
 
-  try {
-    const { remove } = await import("./remove");
+    try {
+      const { remove } = await import("./remove");
 
-    await expect(
-      remove.parseAsync(["node", "ayanokoji", "--cwd", cwd])
-    ).rejects.toThrow("No Docker Compose file found.");
-    await expect(readdir(cwd)).resolves.toStrictEqual([]);
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
+      await expect(
+        remove.parseAsync(["node", "ayanokoji", "--cwd", cwd])
+      ).rejects.toThrow("No Docker Compose file found.");
+      await expect(readdir(cwd)).resolves.toStrictEqual([]);
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 
-test("remove reports no services without writing a valid document", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
-  const composePath = path.join(cwd, "compose.yaml");
-  const source = "name: example\nnetworks:\n  internal: {}\n";
-  await writeFile(composePath, source);
+  test("remove reports no services without writing a valid document", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+    const composePath = path.join(cwd, "compose.yaml");
+    const source = "name: example\nnetworks:\n  internal: {}\n";
+    await writeFile(composePath, source);
 
-  try {
-    const { remove } = await import("./remove");
+    try {
+      const { remove } = await import("./remove");
 
-    await expect(
-      remove.parseAsync(["node", "ayanokoji", "--cwd", cwd])
-    ).rejects.toThrow("No services found in the compose file.");
-    expect(await readFile(composePath, "utf-8")).toBe(source);
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
+      await expect(
+        remove.parseAsync(["node", "ayanokoji", "--cwd", cwd])
+      ).rejects.toThrow("No services found in the compose file.");
+      await expect(readFile(composePath, "utf-8")).resolves.toBe(source);
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 
-test("remove prompts for a candidate when multiple Compose files exist", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
-  const firstPath = path.join(cwd, "compose.yaml");
-  const secondPath = path.join(cwd, "docker-compose.yml");
-  const source = `services:
+  test("remove prompts for a candidate when multiple Compose files exist", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+    const firstPath = path.join(cwd, "compose.yaml");
+    const secondPath = path.join(cwd, "docker-compose.yml");
+    const source = `services:
   postgres:
     image: postgres:17
 `;
-  await writeFile(firstPath, source);
-  await writeFile(secondPath, source);
+    await writeFile(firstPath, source);
+    await writeFile(secondPath, source);
 
-  // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
-  // oxlint-disable-next-line require-await
-  enhancedSelectMock.mockImplementationOnce(async () => "docker-compose.yml");
+    // Preserve the prompt helper's Promise-returning contract in this Vitest mock.
+    // oxlint-disable-next-line require-await
+    enhancedSelectMock.mockResolvedValueOnce("docker-compose.yml");
 
-  try {
-    const { remove } = await import("./remove");
-    await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
+    try {
+      const { remove } = await import("./remove");
+      await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
 
-    expect(await readFile(secondPath, "utf-8")).not.toBe(source);
-    expect(await readFile(firstPath, "utf-8")).toBe(source);
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
+      await expect(readFile(secondPath, "utf-8")).resolves.not.toBe(source);
+      await expect(readFile(firstPath, "utf-8")).resolves.toBe(source);
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 
-test("remove reports an environment failure after the Compose file is written", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
-  const composePath = path.join(cwd, "compose.yaml");
-  const envPath = path.join(cwd, "env-directory");
-  await writeFile(
-    composePath,
-    `services:
+  test("remove reports an environment failure after the Compose file is written", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+    const composePath = path.join(cwd, "compose.yaml");
+    const envPath = path.join(cwd, "env-directory");
+    await writeFile(
+      composePath,
+      `services:
   postgres:
     image: postgres:17
 `
-  );
-  await mkdir(envPath);
-
-  try {
-    const { remove } = await import("./remove");
-
-    await expect(
-      remove.parseAsync([
-        "node",
-        "ayanokoji",
-        "--cwd",
-        cwd,
-        "--env-path",
-        envPath,
-      ])
-    ).rejects.toThrow(
-      "Docker Compose file was written successfully, but environment synchronization failed"
     );
+    await mkdir(envPath);
 
-    expect(await readFile(composePath, "utf-8")).not.toContain("postgres:");
-  } finally {
-    await rm(cwd, { force: true, recursive: true });
-  }
-});
+    try {
+      const { remove } = await import("./remove");
 
-test("remove synchronizes environment cleanup after a successful Compose write", async () => {
-  const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
-  const composePath = path.join(cwd, "compose.yaml");
-  const envPath = path.join(cwd, ".env");
-  await writeFile(
-    composePath,
-    `services:
+      await expect(
+        remove.parseAsync([
+          "node",
+          "ayanokoji",
+          "--cwd",
+          cwd,
+          "--env-path",
+          envPath,
+        ])
+      ).rejects.toThrow(
+        "Docker Compose file was written successfully, but environment synchronization failed"
+      );
+
+      await expect(readFile(composePath, "utf-8")).resolves.not.toContain(
+        "postgres:"
+      );
+    } finally {
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
+
+  test("remove synchronizes environment cleanup after a successful Compose write", async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), "ayanokoji-compose-remove-"));
+    const composePath = path.join(cwd, "compose.yaml");
+    const envPath = path.join(cwd, ".env");
+    await writeFile(
+      composePath,
+      `services:
   postgres:
     image: postgres:17
 `
-  );
-  await writeFile(envPath, "POSTGRESQL_URL=postgresql://docker\n");
-  confirmState.value = true;
+    );
+    await writeFile(envPath, "POSTGRESQL_URL=postgresql://docker\n");
+    confirmState.value = true;
 
-  try {
-    const { remove } = await import("./remove");
-    await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
+    try {
+      const { remove } = await import("./remove");
+      await remove.parseAsync(["node", "ayanokoji", "--cwd", cwd]);
 
-    expect(await readFile(composePath, "utf-8")).not.toContain("postgres:");
-    expect(await readFile(envPath, "utf-8")).toBe("\n");
-  } finally {
-    confirmState.value = false;
-    await rm(cwd, { force: true, recursive: true });
-  }
+      await expect(readFile(composePath, "utf-8")).resolves.not.toContain(
+        "postgres:"
+      );
+      await expect(readFile(envPath, "utf-8")).resolves.toBe("\n");
+    } finally {
+      confirmState.value = false;
+      await rm(cwd, { force: true, recursive: true });
+    }
+  });
 });

--- a/packages/cli/src/commands/docker/schemas/port.test.ts
+++ b/packages/cli/src/commands/docker/schemas/port.test.ts
@@ -1,11 +1,13 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { validatePort } from "./port";
 
-test("returns undefined for a valid port", () => {
-  expect(validatePort("5432", 5432)).toBeUndefined();
-});
+describe("port validation", () => {
+  test("returns undefined for a valid port", () => {
+    expect(validatePort("5432", 5432)).toBeUndefined();
+  });
 
-test("returns a validation message for an invalid port", () => {
-  expect(validatePort("0", 5432)).toContain("Port must be greater than 0");
+  test("returns a validation message for an invalid port", () => {
+    expect(validatePort("0", 5432)).toContain("Port must be greater than 0");
+  });
 });

--- a/packages/cli/src/utils/get-package-json.test.ts
+++ b/packages/cli/src/utils/get-package-json.test.ts
@@ -2,50 +2,54 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { afterEach, expect, test } from "vitest";
+import { afterEach, describe, expect, test } from "vitest";
 
 import { getPackageJson } from "./get-package-json";
 
 const temporaryDirectories: string[] = [];
 
-afterEach(async () => {
-  await Promise.all(
-    temporaryDirectories.splice(0).map(async (directory) => {
-      await rm(directory, { force: true, recursive: true });
-    })
-  );
-});
+describe(getPackageJson, () => {
+  afterEach(async () => {
+    await Promise.all(
+      temporaryDirectories.splice(0).map(async (directory) => {
+        await rm(directory, { force: true, recursive: true });
+      })
+    );
+  });
 
-async function writePackageJson(content: string) {
-  const directory = await mkdtemp(
-    path.join(tmpdir(), "ayanokoji-package-json-")
-  );
-  temporaryDirectories.push(directory);
-  await writeFile(path.join(directory, "package.json"), content);
-  return directory;
-}
-
-test("reads a package JSON object with string scripts", async () => {
-  const directory = await writePackageJson(
-    JSON.stringify({ name: "example", scripts: { test: "vitest" } })
-  );
-
-  const result = await getPackageJson(directory);
-
-  expect(result.isOk()).toBe(true);
-  if (result.isOk()) {
-    expect(result.value.scripts).toStrictEqual({ test: "vitest" });
+  async function writePackageJson(content: string) {
+    const directory = await mkdtemp(
+      path.join(tmpdir(), "ayanokoji-package-json-")
+    );
+    temporaryDirectories.push(directory);
+    await writeFile(path.join(directory, "package.json"), content);
+    return directory;
   }
-});
 
-test.each([
-  ["a JSON primitive", "null"],
-  ["an invalid scripts value", JSON.stringify({ scripts: 42 })],
-  ["malformed JSON", "{invalid"],
-])("rejects %s", async (_description, content) => {
-  const directory = await writePackageJson(content);
+  test("reads a package JSON object with string scripts", async () => {
+    const directory = await writePackageJson(
+      JSON.stringify({ name: "example", scripts: { test: "vitest" } })
+    );
 
-  const result = await getPackageJson(directory);
+    const result = await getPackageJson(directory);
 
-  expect(result.isErr()).toBe(true);
+    expect(result.isOk()).toBeTruthy();
+    if (result.isErr()) {
+      return;
+    }
+
+    expect(result.value.scripts).toStrictEqual({ test: "vitest" });
+  });
+
+  test.each([
+    ["a JSON primitive", "null"],
+    ["an invalid scripts value", JSON.stringify({ scripts: 42 })],
+    ["malformed JSON", "{invalid"],
+  ])("rejects %s", async (_description, content) => {
+    const directory = await writePackageJson(content);
+
+    const result = await getPackageJson(directory);
+
+    expect(result.isErr()).toBeTruthy();
+  });
 });

--- a/packages/cli/src/utils/parse-env.test.ts
+++ b/packages/cli/src/utils/parse-env.test.ts
@@ -1,17 +1,19 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { parseEnv } from "./parse-env";
 
-test("parses quoted and colon-delimited values across Windows line endings", () => {
-  const env = [
-    "export API_KEY = secret",
-    'MESSAGE = "hello\\nworld"',
-    "LABEL: 'quoted value'",
-  ].join("\r\n");
+describe("environment parsing", () => {
+  test("parses quoted and colon-delimited values across Windows line endings", () => {
+    const env = [
+      "export API_KEY = secret",
+      'MESSAGE = "hello\\nworld"',
+      "LABEL: 'quoted value'",
+    ].join("\r\n");
 
-  expect(parseEnv(env)).toStrictEqual({
-    API_KEY: "secret",
-    LABEL: "quoted value",
-    MESSAGE: "hello\nworld",
+    expect(parseEnv(env)).toStrictEqual({
+      API_KEY: "secret",
+      LABEL: "quoted value",
+      MESSAGE: "hello\nworld",
+    });
   });
 });

--- a/packages/cli/src/utils/result.test.ts
+++ b/packages/cli/src/utils/result.test.ts
@@ -1,19 +1,21 @@
-import { expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 
 import { Err, Ok } from "./result";
 
-test("Ok stores its value and identifies a successful result", () => {
-  const result = new Ok<number, string>(42);
+describe("Result", () => {
+  test("Ok stores its value and identifies a successful result", () => {
+    const result = new Ok<number, string>(42);
 
-  expect(result.value).toBe(42);
-  expect(result.isOk()).toBe(true);
-  expect(result.isErr()).toBe(false);
-});
+    expect(result.value).toBe(42);
+    expect(result.isOk()).toBeTruthy();
+    expect(result.isErr()).toBeFalsy();
+  });
 
-test("Err stores its error and identifies a failed result", () => {
-  const result = new Err<number, string>("failure");
+  test("Err stores its error and identifies a failed result", () => {
+    const result = new Err<number, string>("failure");
 
-  expect(result.error).toBe("failure");
-  expect(result.isOk()).toBe(false);
-  expect(result.isErr()).toBe(true);
+    expect(result.error).toBe("failure");
+    expect(result.isOk()).toBeFalsy();
+    expect(result.isErr()).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Enable Ultracite's Vitest preset and resolve its test diagnostics with a narrow Node test runner exception.

Closes #76

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>